### PR TITLE
Script snippets, plugin system, and ephemeral paste

### DIFF
--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -93,6 +93,10 @@
 		FAC43E2B1B35DFDF00C06102 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FAC43E2A1B35DFDF00C06102 /* WebKit.framework */; };
 		FAE911B91DE045E2008A4BEC /* HotKeyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE911B81DE045E2008A4BEC /* HotKeyService.swift */; };
 		FAE911BB1DE054F1008A4BEC /* NSCoding+Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE911BA1DE054F1008A4BEC /* NSCoding+Archive.swift */; };
+		CC06A8D20A26E90A00667788 /* ScriptExecutionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC06A8D10A26E90A00667788 /* ScriptExecutionService.swift */; };
+		CC07B9E30B37FA1B00778899 /* Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07B9E20B37FA1B00778899 /* Plugin.swift */; };
+		CC08CAF20C48FB2C00889900 /* PluginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC08CAF10C48FB2C00889900 /* PluginManager.swift */; };
+		CC09DB040D59FC3D00990011 /* SnippetTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC09DB030D59FC3D00990011 /* SnippetTemplates.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -252,6 +256,10 @@
 		FAC43E2A1B35DFDF00C06102 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		FAE911B81DE045E2008A4BEC /* HotKeyService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HotKeyService.swift; sourceTree = "<group>"; };
 		FAE911BA1DE054F1008A4BEC /* NSCoding+Archive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSCoding+Archive.swift"; sourceTree = "<group>"; };
+		CC06A8D10A26E90A00667788 /* ScriptExecutionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptExecutionService.swift; sourceTree = "<group>"; };
+		CC07B9E20B37FA1B00778899 /* Plugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plugin.swift; sourceTree = "<group>"; };
+		CC08CAF10C48FB2C00889900 /* PluginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginManager.swift; sourceTree = "<group>"; };
+		CC09DB030D59FC3D00990011 /* SnippetTemplates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetTemplates.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -336,8 +344,18 @@
 				CB05E7E3FB15E8FF00556699 /* RealmEncryptionService.swift */,
 				CB05E7E5FB15E9FF00556699 /* UsageMetricsService.swift */,
 				CB05E7DBFB15E8FD00556699 /* VaultAuthService.swift */,
+				CC06A8D10A26E90A00667788 /* ScriptExecutionService.swift */,
 			);
 			path = Services;
+			sourceTree = "<group>";
+		};
+		CC07B9E00B37FA1B00778800 /* Plugins */ = {
+			isa = PBXGroup;
+			children = (
+				CC07B9E20B37FA1B00778899 /* Plugin.swift */,
+				CC08CAF10C48FB2C00889900 /* PluginManager.swift */,
+			);
+			path = Plugins;
 			sourceTree = "<group>";
 		};
 		FA10897A20EC229300A3FEFC /* Generated */ = {
@@ -364,6 +382,7 @@
 			children = (
 				FA3778911F3B690D003B5BAB /* Environments */,
 				FA0D5CE61DDCC5D000AC9052 /* Services */,
+				CC07B9E00B37FA1B00778800 /* Plugins */,
 				CB05E7E2FB15E8FE00556699 /* Onboarding */,
 				FA1DB4EC1DDCB4C0007F95C8 /* Preferences */,
 				FA1DB50C1DDCB4C0007F95C8 /* Snippets */,
@@ -534,6 +553,7 @@
 			children = (
 				FA1DB50D1DDCB4C0007F95C8 /* CPYSnippetsEditorWindowController.swift */,
 				802DE837E59DA8EA94C6B53A /* ModernSnippetsEditor.swift */,
+				CC09DB030D59FC3D00990011 /* SnippetTemplates.swift */,
 				FA1DB50F1DDCB4C0007F95C8 /* CPYSnippetsEditorWindowController.xib */,
 			);
 			path = Snippets;
@@ -952,6 +972,10 @@
 				CB01A3F7E7D1A4B900112255 /* SyntaxHighlighter.swift in Sources */,
 				CB02B4A9F8E2B5CA00223366 /* ClipIntelligence.swift in Sources */,
 				FD44C0065950E4DBB9CF2AE8 /* ModernPreferencesWindow.swift in Sources */,
+				CC06A8D20A26E90A00667788 /* ScriptExecutionService.swift in Sources */,
+				CC07B9E30B37FA1B00778899 /* Plugin.swift in Sources */,
+				CC08CAF20C48FB2C00889900 /* PluginManager.swift in Sources */,
+				CC09DB040D59FC3D00990011 /* SnippetTemplates.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -90,7 +90,7 @@ class AppDelegate: NSObject, NSMenuItemValidation {
     @objc func clearAllHistory() {
         let isShowAlert = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.showAlertBeforeClearHistory)
         if isShowAlert {
-            
+
             let alert = NSAlert()
             alert.messageText = L10n.clearHistory
             alert.informativeText = L10n.areYouSureYouWantToClearYourClipboardHistory

--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -140,9 +140,39 @@ class AppDelegate: NSObject, NSMenuItemValidation {
             NSSound.beep()
             return
         }
-        let processed = SnippetVariableProcessor.process(snippet.content)
-        AppEnvironment.current.pasteService.copyToPasteboard(with: processed)
-        AppEnvironment.current.pasteService.paste()
+
+        switch snippet.type {
+        case .plainText:
+            let processed = SnippetVariableProcessor.process(snippet.content)
+            AppEnvironment.current.pasteService.copyToPasteboard(with: processed)
+            AppEnvironment.current.pasteService.paste()
+        case .script:
+            let script = snippet.content
+            let shell = snippet.scriptShell
+            let timeout = TimeInterval(snippet.scriptTimeout)
+            let ephemeral = snippet.isEphemeral
+            ScriptExecutionService.execute(script: script, shell: shell, timeout: timeout) { result in
+                if result.timedOut {
+                    Self.showScriptError("Script timed out after \(Int(timeout))s")
+                } else if result.exitCode != 0, let error = result.error {
+                    Self.showScriptError("Script failed (exit \(result.exitCode)): \(error)")
+                } else if ephemeral {
+                    AppEnvironment.current.pasteService.pasteEphemeral(with: result.output)
+                } else {
+                    AppEnvironment.current.pasteService.copyToPasteboard(with: result.output)
+                    AppEnvironment.current.pasteService.paste()
+                }
+            }
+        }
+    }
+
+    private static func showScriptError(_ message: String) {
+        let alert = NSAlert()
+        alert.messageText = "Script Snippet Error"
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
     }
 
     func terminateApplication() {

--- a/Clipy/Sources/AppDelegate.swift
+++ b/Clipy/Sources/AppDelegate.swift
@@ -90,6 +90,7 @@ class AppDelegate: NSObject, NSMenuItemValidation {
     @objc func clearAllHistory() {
         let isShowAlert = AppEnvironment.current.defaults.bool(forKey: Constants.UserDefaults.showAlertBeforeClearHistory)
         if isShowAlert {
+            
             let alert = NSAlert()
             alert.messageText = L10n.clearHistory
             alert.informativeText = L10n.areYouSureYouWantToClearYourClipboardHistory
@@ -154,8 +155,9 @@ class AppDelegate: NSObject, NSMenuItemValidation {
             ScriptExecutionService.execute(script: script, shell: shell, timeout: timeout) { result in
                 if result.timedOut {
                     Self.showScriptError("Script timed out after \(Int(timeout))s")
-                } else if result.exitCode != 0, let error = result.error {
-                    Self.showScriptError("Script failed (exit \(result.exitCode)): \(error)")
+                } else if result.exitCode != 0 {
+                    let detail = result.error ?? "No error output"
+                    Self.showScriptError("Script failed (exit \(result.exitCode)): \(detail)")
                 } else if ephemeral {
                     AppEnvironment.current.pasteService.pasteEphemeral(with: result.output)
                 } else {

--- a/Clipy/Sources/Constants.swift
+++ b/Clipy/Sources/Constants.swift
@@ -69,6 +69,7 @@ struct Constants {
         static let collectCrashReport = "kCPYCollectCrashReport"
         static let showColorPreviewInTheMenu = "kCPYPrefShowColorPreviewInTheMenu"
         static let clearHistoryIncludesPinned = "kCPYPrefClearHistoryIncludesPinned"
+        static let ephemeralAutoClearSeconds = "kCPYPrefEphemeralAutoClearSeconds"
     }
 
     struct Beta {

--- a/Clipy/Sources/Extensions/Realm+Migration.swift
+++ b/Clipy/Sources/Extensions/Realm+Migration.swift
@@ -15,7 +15,7 @@ private let logger = Logger(subsystem: "com.clipy-app.Clipy", category: "Migrati
 
 extension Realm {
     static func migration() {
-        let config = Realm.Configuration(schemaVersion: 10, migrationBlock: { migration, oldSchemaVersion in
+        let config = Realm.Configuration(schemaVersion: 12, migrationBlock: { migration, oldSchemaVersion in
             if oldSchemaVersion <= 2 {
                 migration.enumerateObjects(ofType: CPYSnippet.className()) { _, newObject in
                     newObject?["identifier"] = NSUUID().uuidString
@@ -69,6 +69,20 @@ extension Realm {
                 // Schema 10: Added ocrText field to CPYClip
                 migration.enumerateObjects(ofType: CPYClip.className()) { _, newObject in
                     newObject?["ocrText"] = nil
+                }
+            }
+            if oldSchemaVersion <= 10 {
+                // Schema 11: Added script snippet fields to CPYSnippet
+                migration.enumerateObjects(ofType: CPYSnippet.className()) { _, newObject in
+                    newObject?["snippetType"] = CPYSnippet.SnippetType.plainText.rawValue
+                    newObject?["scriptShell"] = CPYSnippet.defaultShell
+                    newObject?["scriptTimeout"] = CPYSnippet.defaultTimeout
+                }
+            }
+            if oldSchemaVersion <= 11 {
+                // Schema 12: Added isEphemeral field to CPYSnippet
+                migration.enumerateObjects(ofType: CPYSnippet.className()) { _, newObject in
+                    newObject?["isEphemeral"] = true
                 }
             }
         })

--- a/Clipy/Sources/Managers/MenuManager.swift
+++ b/Clipy/Sources/Managers/MenuManager.swift
@@ -558,8 +558,18 @@ private extension MenuManager {
 
         let menuItem = NSMenuItem(title: titleWithMark, action: #selector(AppDelegate.selectSnippetMenuItem(_:)), keyEquivalent: "")
         menuItem.representedObject = snippet.identifier
-        menuItem.toolTip = snippet.content
-        menuItem.image = (isShowIcon) ? snippetIcon : nil
+
+        if snippet.type == .script {
+            menuItem.toolTip = "[Script] \(snippet.content)"
+            if isShowIcon, let scriptIcon = NSImage(systemSymbolName: "terminal.fill", accessibilityDescription: "Script") {
+                scriptIcon.isTemplate = true
+                scriptIcon.size = NSSize(width: 12, height: 13)
+                menuItem.image = scriptIcon
+            }
+        } else {
+            menuItem.toolTip = snippet.content
+            menuItem.image = (isShowIcon) ? snippetIcon : nil
+        }
 
         return menuItem
     }

--- a/Clipy/Sources/Models/CPYSnippet.swift
+++ b/Clipy/Sources/Models/CPYSnippet.swift
@@ -14,16 +14,35 @@ import RealmSwift
 
 final class CPYSnippet: Object {
 
+    // MARK: - Snippet Type
+    enum SnippetType: Int {
+        case plainText = 0
+        case script = 1
+    }
+
+    // MARK: - Defaults
+    static let defaultShell = "/bin/bash"
+    static let defaultTimeout = 10
+
     // MARK: - Properties
     @objc dynamic var index = 0
     @objc dynamic var enable = true
     @objc dynamic var title = ""
     @objc dynamic var content = ""
     @objc dynamic var identifier = UUID().uuidString
+    @objc dynamic var snippetType = SnippetType.plainText.rawValue
+    @objc dynamic var scriptShell = CPYSnippet.defaultShell
+    @objc dynamic var scriptTimeout = CPYSnippet.defaultTimeout  // seconds
+    @objc dynamic var isEphemeral = true  // script outputs not saved to history
     let folders = LinkingObjects(fromType: CPYFolder.self, property: "snippets")
 
     var folder: CPYFolder? {
         return folders.first
+    }
+
+    var type: SnippetType {
+        get { SnippetType(rawValue: snippetType) ?? .plainText }
+        set { snippetType = newValue.rawValue }
     }
 
     // MARK: Primary Key

--- a/Clipy/Sources/Plugins/Plugin.swift
+++ b/Clipy/Sources/Plugins/Plugin.swift
@@ -1,0 +1,73 @@
+//
+//  Plugin.swift
+//
+//  Clipy
+//
+//  Plugin model for the clip processor plugin system.
+//
+
+import Foundation
+
+struct Plugin: Identifiable, Codable {
+    let id: String          // directory name
+    let name: String
+    let version: String
+    let description: String
+    let author: String
+    let type: PluginType
+    let trigger: PluginTrigger
+    let inputTypes: [String]
+    let command: String
+    let timeout: Int
+
+    var isEnabled: Bool = true
+    var directoryURL: URL?
+
+    enum PluginType: String, Codable {
+        case processor
+        case filter
+        case annotator
+    }
+
+    enum PluginTrigger: String, Codable {
+        case auto       // runs on every clipboard capture
+        case manual     // user triggers explicitly
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, version, description, author, type, trigger
+        case inputTypes = "input_types"
+        case command, timeout
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // id is set externally from directory name, use placeholder
+        id = try container.decodeIfPresent(String.self, forKey: .id) ?? ""
+        name = try container.decode(String.self, forKey: .name)
+        version = try container.decodeIfPresent(String.self, forKey: .version) ?? "1.0"
+        description = try container.decodeIfPresent(String.self, forKey: .description) ?? ""
+        author = try container.decodeIfPresent(String.self, forKey: .author) ?? ""
+        type = try container.decodeIfPresent(PluginType.self, forKey: .type) ?? .processor
+        trigger = try container.decodeIfPresent(PluginTrigger.self, forKey: .trigger) ?? .manual
+        inputTypes = try container.decodeIfPresent([String].self, forKey: .inputTypes) ?? ["string"]
+        command = try container.decode(String.self, forKey: .command)
+        timeout = try container.decodeIfPresent(Int.self, forKey: .timeout) ?? 5
+    }
+
+    init(id: String, name: String, version: String, description: String, author: String,
+         type: PluginType, trigger: PluginTrigger, inputTypes: [String],
+         command: String, timeout: Int, directoryURL: URL?) {
+        self.id = id
+        self.name = name
+        self.version = version
+        self.description = description
+        self.author = author
+        self.type = type
+        self.trigger = trigger
+        self.inputTypes = inputTypes
+        self.command = command
+        self.timeout = timeout
+        self.directoryURL = directoryURL
+    }
+}

--- a/Clipy/Sources/Plugins/PluginManager.swift
+++ b/Clipy/Sources/Plugins/PluginManager.swift
@@ -1,0 +1,189 @@
+//
+//  PluginManager.swift
+//
+//  Clipy
+//
+//  Scans ~/.clipy/plugins/, loads plugin manifests, and runs plugins
+//  via ScriptExecutionService.
+//
+
+import Foundation
+import Cocoa
+import os.log
+
+private let logger = Logger(subsystem: "com.clipy-app.Clipy", category: "Plugins")
+
+private let kPluginEnabledStates = "kCPYPluginEnabledStates"
+
+@MainActor
+class PluginManager: ObservableObject {
+    static let shared = PluginManager()
+
+    @Published var plugins = [Plugin]()
+
+    /// Fast check to skip auto-plugin work when none are registered.
+    var hasAutoPlugins: Bool {
+        plugins.contains { $0.isEnabled && $0.trigger == .auto }
+    }
+
+    /// Base directory for user plugins.
+    static var pluginsDirectoryURL: URL {
+        URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(".clipy/plugins", isDirectory: true)
+    }
+
+    private var fileWatcher: DispatchSourceFileSystemObject?
+    private var reloadDebounce: DispatchWorkItem?
+
+    private init() {
+        ensurePluginsDirectory()
+        reload()
+        startWatching()
+    }
+
+    // MARK: - Directory Setup
+
+    private func ensurePluginsDirectory() {
+        let url = Self.pluginsDirectoryURL
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    // MARK: - Loading
+
+    func reload() {
+        let baseURL = Self.pluginsDirectoryURL
+        guard let contents = try? FileManager.default.contentsOfDirectory(
+            at: baseURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            plugins = []
+            return
+        }
+
+        let enabledIDs = enabledPluginIDs()
+
+        plugins = contents.compactMap { dirURL -> Plugin? in
+            guard (try? dirURL.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true else { return nil }
+            let manifestURL = dirURL.appendingPathComponent("manifest.json")
+            guard let data = try? Data(contentsOf: manifestURL) else {
+                logger.warning("No manifest.json in plugin \(dirURL.lastPathComponent)")
+                return nil
+            }
+            guard var plugin = try? JSONDecoder().decode(Plugin.self, from: data) else {
+                logger.error("Invalid manifest.json in plugin \(dirURL.lastPathComponent)")
+                return nil
+            }
+            plugin = Plugin(
+                id: dirURL.lastPathComponent,
+                name: plugin.name,
+                version: plugin.version,
+                description: plugin.description,
+                author: plugin.author,
+                type: plugin.type,
+                trigger: plugin.trigger,
+                inputTypes: plugin.inputTypes,
+                command: plugin.command,
+                timeout: plugin.timeout,
+                directoryURL: dirURL
+            )
+            plugin.isEnabled = enabledIDs[plugin.id] ?? true
+            return plugin
+        }
+
+        logger.info("Loaded \(self.plugins.count) plugin(s)")
+    }
+
+    // MARK: - Plugin Execution
+
+    /// Run a plugin with the given input string.
+    func run(_ plugin: Plugin, input: String, completion: @escaping (ScriptExecutionService.Result) -> Void) {
+        guard let dirURL = plugin.directoryURL else {
+            completion(ScriptExecutionService.Result(output: "", exitCode: -1, timedOut: false, error: "Plugin directory not found"))
+            return
+        }
+
+        // Quote the command path to handle spaces/special characters safely
+        let commandPath = dirURL.appendingPathComponent(plugin.command).path
+        let quotedCommand = "'\(commandPath.replacingOccurrences(of: "'", with: "'\\''"))'"
+
+        ScriptExecutionService.execute(
+            script: quotedCommand,
+            shell: CPYSnippet.defaultShell,
+            timeout: TimeInterval(plugin.timeout),
+            environment: ["CLIPY_INPUT": input, "PLUGIN_DIR": dirURL.path],
+            completion: completion
+        )
+    }
+
+    /// Run all enabled auto-trigger plugins on the given input.
+    func runAutoPlugins(input: String) {
+        guard hasAutoPlugins else { return }
+        let autoPlugins = plugins.filter { $0.isEnabled && $0.trigger == .auto }
+        for plugin in autoPlugins {
+            run(plugin, input: input) { result in
+                if result.exitCode != 0 {
+                    logger.warning("Auto plugin '\(plugin.name)' failed: \(result.error ?? "unknown")")
+                }
+            }
+        }
+    }
+
+    // MARK: - Enable/Disable
+
+    func setEnabled(_ pluginID: String, enabled: Bool) {
+        if let index = plugins.firstIndex(where: { $0.id == pluginID }) {
+            plugins[index].isEnabled = enabled
+        }
+        saveEnabledPluginIDs()
+    }
+
+    private func enabledPluginIDs() -> [String: Bool] {
+        UserDefaults.standard.dictionary(forKey: kPluginEnabledStates) as? [String: Bool] ?? [:]
+    }
+
+    private func saveEnabledPluginIDs() {
+        var states = [String: Bool]()
+        for plugin in plugins {
+            states[plugin.id] = plugin.isEnabled
+        }
+        UserDefaults.standard.set(states, forKey: kPluginEnabledStates)
+    }
+
+    // MARK: - File Watching
+
+    private func startWatching() {
+        let path = Self.pluginsDirectoryURL.path
+        let fd = open(path, O_EVTONLY)
+        guard fd >= 0 else { return }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .rename, .delete],
+            queue: .global()
+        )
+
+        source.setEventHandler { [weak self] in
+            // Debounce: wait 0.5s after last event before reloading
+            DispatchQueue.main.async {
+                self?.reloadDebounce?.cancel()
+                let work = DispatchWorkItem { [weak self] in
+                    self?.reload()
+                }
+                self?.reloadDebounce = work
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: work)
+            }
+        }
+
+        source.setCancelHandler {
+            close(fd)
+        }
+
+        source.resume()
+        fileWatcher = source
+    }
+
+    /// Open the plugins directory in Finder.
+    func openPluginsFolder() {
+        NSWorkspace.shared.open(Self.pluginsDirectoryURL)
+    }
+}

--- a/Clipy/Sources/Plugins/PluginManager.swift
+++ b/Clipy/Sources/Plugins/PluginManager.swift
@@ -51,46 +51,45 @@ class PluginManager: ObservableObject {
 
     func reload() {
         let baseURL = Self.pluginsDirectoryURL
-        guard let contents = try? FileManager.default.contentsOfDirectory(
-            at: baseURL,
-            includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            plugins = []
-            return
-        }
+        let savedEnabledIDs = enabledPluginIDs()
 
-        let enabledIDs = enabledPluginIDs()
-
-        plugins = contents.compactMap { dirURL -> Plugin? in
-            guard (try? dirURL.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true else { return nil }
-            let manifestURL = dirURL.appendingPathComponent("manifest.json")
-            guard let data = try? Data(contentsOf: manifestURL) else {
-                logger.warning("No manifest.json in plugin \(dirURL.lastPathComponent)")
-                return nil
+        Task.detached(priority: .userInitiated) { [weak self] in
+            guard let contents = try? FileManager.default.contentsOfDirectory(
+                at: baseURL,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            ) else {
+                await MainActor.run { self?.plugins = [] }
+                return
             }
-            guard var plugin = try? JSONDecoder().decode(Plugin.self, from: data) else {
-                logger.error("Invalid manifest.json in plugin \(dirURL.lastPathComponent)")
-                return nil
-            }
-            plugin = Plugin(
-                id: dirURL.lastPathComponent,
-                name: plugin.name,
-                version: plugin.version,
-                description: plugin.description,
-                author: plugin.author,
-                type: plugin.type,
-                trigger: plugin.trigger,
-                inputTypes: plugin.inputTypes,
-                command: plugin.command,
-                timeout: plugin.timeout,
-                directoryURL: dirURL
-            )
-            plugin.isEnabled = enabledIDs[plugin.id] ?? true
-            return plugin
-        }
 
-        logger.info("Loaded \(self.plugins.count) plugin(s)")
+            let loaded: [Plugin] = contents.compactMap { dirURL -> Plugin? in
+                guard (try? dirURL.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true else { return nil }
+                let manifestURL = dirURL.appendingPathComponent("manifest.json")
+                guard let data = try? Data(contentsOf: manifestURL) else { return nil }
+                guard var plugin = try? JSONDecoder().decode(Plugin.self, from: data) else { return nil }
+                plugin = Plugin(
+                    id: dirURL.lastPathComponent,
+                    name: plugin.name,
+                    version: plugin.version,
+                    description: plugin.description,
+                    author: plugin.author,
+                    type: plugin.type,
+                    trigger: plugin.trigger,
+                    inputTypes: plugin.inputTypes,
+                    command: plugin.command,
+                    timeout: plugin.timeout,
+                    directoryURL: dirURL
+                )
+                plugin.isEnabled = savedEnabledIDs[plugin.id] ?? true
+                return plugin
+            }
+
+            await MainActor.run {
+                self?.plugins = loaded
+                logger.info("Loaded \(loaded.count) plugin(s)")
+            }
+        }
     }
 
     // MARK: - Plugin Execution

--- a/Clipy/Sources/Plugins/PluginManager.swift
+++ b/Clipy/Sources/Plugins/PluginManager.swift
@@ -81,7 +81,7 @@ class PluginManager: ObservableObject {
                     timeout: plugin.timeout,
                     directoryURL: dirURL
                 )
-                plugin.isEnabled = savedEnabledIDs[plugin.id] ?? true
+                plugin.isEnabled = savedEnabledIDs[plugin.id] ?? false
                 return plugin
             }
 
@@ -101,12 +101,22 @@ class PluginManager: ObservableObject {
             return
         }
 
-        // Quote the command path to handle spaces/special characters safely
-        let commandPath = dirURL.appendingPathComponent(plugin.command).path
-        let quotedCommand = "'\(commandPath.replacingOccurrences(of: "'", with: "'\\''"))'"
+        // Validate command is a relative path without traversal
+        let command = plugin.command
+        guard !command.hasPrefix("/") && !command.contains("..") else {
+            completion(ScriptExecutionService.Result(output: "", exitCode: -1, timedOut: false, error: "Invalid plugin command path"))
+            return
+        }
+        let commandURL = dirURL.appendingPathComponent(command).standardized
+        guard commandURL.path.hasPrefix(dirURL.path) else {
+            completion(ScriptExecutionService.Result(output: "", exitCode: -1, timedOut: false, error: "Plugin command escapes plugin directory"))
+            return
+        }
+
+        let quotedCommand = "'\(commandURL.path.replacingOccurrences(of: "'", with: "'\\''"))'"
 
         ScriptExecutionService.execute(
-            script: quotedCommand,
+            script: "cd '\(dirURL.path.replacingOccurrences(of: "'", with: "'\\''"))' && " + quotedCommand,
             shell: CPYSnippet.defaultShell,
             timeout: TimeInterval(plugin.timeout),
             environment: ["CLIPY_INPUT": input, "PLUGIN_DIR": dirURL.path],

--- a/Clipy/Sources/Preferences/ModernPreferencesWindow.swift
+++ b/Clipy/Sources/Preferences/ModernPreferencesWindow.swift
@@ -18,6 +18,7 @@ enum PreferenceTab: String, Identifiable {
     case types = "Types"
     case shortcuts = "Shortcuts"
     case excludedApps = "Excluded Apps"
+    case plugins = "Plugins"
     case updates = "Updates"
     case developer = "Developer"
 
@@ -30,6 +31,7 @@ enum PreferenceTab: String, Identifiable {
         case .types: return "doc.on.clipboard"
         case .shortcuts: return "keyboard"
         case .excludedApps: return "xmark.app"
+        case .plugins: return "puzzlepiece.extension"
         case .updates: return "arrow.triangle.2.circlepath"
         case .developer: return "hammer"
         }
@@ -37,7 +39,7 @@ enum PreferenceTab: String, Identifiable {
 
     /// Tabs visible by default (developer tab requires dev mode)
     static var visibleTabs: [PreferenceTab] {
-        var tabs: [PreferenceTab] = [.general, .menu, .types, .shortcuts, .excludedApps, .updates]
+        var tabs: [PreferenceTab] = [.general, .menu, .types, .shortcuts, .excludedApps, .plugins, .updates]
         if UserDefaults.standard.bool(forKey: Constants.Developer.devModeEnabled) {
             tabs.append(.developer)
         }
@@ -101,6 +103,8 @@ struct ModernPreferencesView: View {
                     ShortcutsPreferencesView()
                 case .excludedApps:
                     ExcludedAppsPreferencesView()
+                case .plugins:
+                    PluginsPreferencesView()
                 case .updates:
                     UpdatesPreferencesView()
                 case .developer:
@@ -141,6 +145,9 @@ struct GeneralPreferencesView: View {
     @AppStorage(Constants.Snippets.useModernPicker)
     private var useModernSnippetPicker = true
 
+    @AppStorage(Constants.UserDefaults.ephemeralAutoClearSeconds)
+    private var ephemeralAutoClear = 30
+
     @AppStorage(Constants.Developer.devModeEnabled)
     private var devMode = false
 
@@ -174,6 +181,14 @@ struct GeneralPreferencesView: View {
                     Text("Last Used").tag(true)
                     Text("Date Created").tag(false)
                 }
+
+                Picker("Auto-clear ephemeral paste", selection: $ephemeralAutoClear) {
+                    Text("Off").tag(0)
+                    Text("15 seconds").tag(15)
+                    Text("30 seconds").tag(30)
+                    Text("60 seconds").tag(60)
+                }
+                .help("Script snippets marked as ephemeral will auto-clear the pasteboard after this delay")
             } header: {
                 Label("Clipboard History", systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90")
             }
@@ -1201,6 +1216,123 @@ enum UpdateState: Equatable {
     case downloading(progress: Double)
     case installing
     case failed(message: String)
+}
+
+// MARK: - Plugins Preferences
+struct PluginsPreferencesView: View {
+    @StateObject private var pluginManager = PluginManager.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text("Plugins")
+                    .font(.system(size: 18, weight: .semibold))
+                Spacer()
+                Button {
+                    pluginManager.reload()
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 10, weight: .semibold))
+                        Text("Reload")
+                            .font(.system(size: 11, weight: .medium))
+                    }
+                }
+                Button {
+                    pluginManager.openPluginsFolder()
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "folder")
+                            .font(.system(size: 10, weight: .semibold))
+                        Text("Open Folder")
+                            .font(.system(size: 11, weight: .medium))
+                    }
+                }
+            }
+
+            Text("Place plugins in ~/.clipy/plugins/ — each plugin is a folder with a manifest.json.")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+
+            if pluginManager.plugins.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "puzzlepiece.extension")
+                        .font(.system(size: 28, weight: .ultraLight))
+                        .foregroundStyle(.quaternary)
+                    Text("No plugins installed")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.tertiary)
+                    Text("Create a folder in ~/.clipy/plugins/ with a manifest.json to get started.")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.quaternary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    VStack(spacing: 4) {
+                        ForEach(pluginManager.plugins) { plugin in
+                            pluginRow(plugin)
+                        }
+                    }
+                }
+            }
+
+            Spacer()
+        }
+        .padding(24)
+    }
+
+    private func pluginRow(_ plugin: Plugin) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: plugin.trigger == .auto ? "bolt.fill" : "hand.tap.fill")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(plugin.isEnabled ? AnyShapeStyle(.blue) : AnyShapeStyle(.quaternary))
+                .frame(width: 28, height: 28)
+                .background(plugin.isEnabled ? SwiftUI.Color.blue.opacity(0.1) : SwiftUI.Color.clear)
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(plugin.name)
+                        .font(.system(size: 12, weight: .medium))
+                    Text("v\(plugin.version)")
+                        .font(.system(size: 9, weight: .medium, design: .rounded))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(.quaternary.opacity(0.3))
+                        .clipShape(Capsule())
+                    Text(plugin.trigger == .auto ? "Auto" : "Manual")
+                        .font(.system(size: 8, weight: .bold, design: .rounded))
+                        .foregroundStyle(plugin.trigger == .auto ? .orange : .blue)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background((plugin.trigger == .auto ? SwiftUI.Color.orange : SwiftUI.Color.blue).opacity(0.1))
+                        .clipShape(Capsule())
+                }
+                if !plugin.description.isEmpty {
+                    Text(plugin.description)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer()
+
+            Toggle("", isOn: Binding(
+                get: { plugin.isEnabled },
+                set: { pluginManager.setEnabled(plugin.id, enabled: $0) }
+            ))
+            .toggleStyle(.switch)
+            .controlSize(.small)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(.white.opacity(0.03))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
 }
 
 struct UpdatesPreferencesView: View {

--- a/Clipy/Sources/Services/ClipService.swift
+++ b/Clipy/Sources/Services/ClipService.swift
@@ -27,23 +27,25 @@ final class ClipService {
     private var cancellables = Set<AnyCancellable>()
 
     /// When > 0, the next N clipboard changes are skipped (not saved to history).
+    /// Specific pasteboard change counts that should be skipped (not saved to history).
     /// Used by ephemeral paste to prevent secrets from being stored.
-    private var skipCaptureCount: Int = 0
+    private var skippedChangeCounts = Set<Int>()
     private let skipLock = NSLock()
 
     /// Tell ClipService to skip the next clipboard change (ephemeral paste).
     func skipNextCapture() {
+        let nextChangeCount = NSPasteboard.general.changeCount
         skipLock.lock()
-        skipCaptureCount += 1
+        skippedChangeCounts.insert(nextChangeCount)
         skipLock.unlock()
     }
 
     /// Check and consume a skip token. Returns true if this capture should be skipped.
     private func shouldSkipCapture() -> Bool {
+        let current = NSPasteboard.general.changeCount
         skipLock.lock()
         defer { skipLock.unlock() }
-        if skipCaptureCount > 0 {
-            skipCaptureCount -= 1
+        if skippedChangeCounts.remove(current) != nil {
             return true
         }
         return false

--- a/Clipy/Sources/Services/ClipService.swift
+++ b/Clipy/Sources/Services/ClipService.swift
@@ -26,6 +26,29 @@ final class ClipService {
     private var monitorTask: Task<Void, Never>?
     private var cancellables = Set<AnyCancellable>()
 
+    /// When > 0, the next N clipboard changes are skipped (not saved to history).
+    /// Used by ephemeral paste to prevent secrets from being stored.
+    private var skipCaptureCount: Int = 0
+    private let skipLock = NSLock()
+
+    /// Tell ClipService to skip the next clipboard change (ephemeral paste).
+    func skipNextCapture() {
+        skipLock.lock()
+        skipCaptureCount += 1
+        skipLock.unlock()
+    }
+
+    /// Check and consume a skip token. Returns true if this capture should be skipped.
+    private func shouldSkipCapture() -> Bool {
+        skipLock.lock()
+        defer { skipLock.unlock() }
+        if skipCaptureCount > 0 {
+            skipCaptureCount -= 1
+            return true
+        }
+        return false
+    }
+
     // MARK: - Thumbnail Cache
     private static let thumbnailCache = NSCache<NSString, NSImage>()
 
@@ -129,6 +152,12 @@ extension ClipService {
     fileprivate func create() {
         lock.lock(); defer { lock.unlock() }
 
+        // Ephemeral paste: skip this clipboard change
+        if shouldSkipCapture() {
+            logger.debug("Skipping ephemeral clipboard capture")
+            return
+        }
+
         // Store types
         if !storeTypes.values.contains(NSNumber(value: true)) { return }
         // Pasteboard types
@@ -203,6 +232,10 @@ extension ClipService {
                         dispatchRealm.add(clip, update: .all)
                     }
                     UsageMetricsService.shared.track(.clipsCopied)
+                    // Run auto-trigger plugins on string content (short-circuits when none registered)
+                    if PluginManager.shared.hasAutoPlugins, !data.stringValue.isEmpty {
+                        PluginManager.shared.runAutoPlugins(input: data.stringValue)
+                    }
                     // Immediately evict oldest non-pinned clips over the limit
                     AppEnvironment.current.dataCleanService.cleanDatas()
                 }

--- a/Clipy/Sources/Services/PasteService.swift
+++ b/Clipy/Sources/Services/PasteService.swift
@@ -138,14 +138,15 @@ extension PasteService {
         // Tell ClipService to skip the next clipboard capture
         AppEnvironment.current.clipService.skipNextCapture()
         copyToPasteboard(with: string)
+        let ephemeralChangeCount = NSPasteboard.general.changeCount
         paste()
 
         // Auto-clear pasteboard after configured delay
         let clearDelay = AppEnvironment.current.defaults.integer(forKey: Constants.UserDefaults.ephemeralAutoClearSeconds)
         if clearDelay > 0 {
             DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(clearDelay)) {
-                // Only clear if the pasteboard still has what we put there
-                if NSPasteboard.general.string(forType: .clipyString) == string {
+                // Only clear if the pasteboard has not changed since we wrote the ephemeral content
+                if NSPasteboard.general.changeCount == ephemeralChangeCount {
                     AppEnvironment.current.clipService.skipNextCapture()
                     NSPasteboard.general.clearContents()
                 }

--- a/Clipy/Sources/Services/PasteService.swift
+++ b/Clipy/Sources/Services/PasteService.swift
@@ -129,6 +129,31 @@ extension PasteService {
     }
 }
 
+// MARK: - Ephemeral Paste
+extension PasteService {
+    /// Paste a string ephemerally — it goes to the pasteboard and triggers ⌘V,
+    /// but ClipService will NOT store it in history. Optionally auto-clears the
+    /// pasteboard after a delay.
+    func pasteEphemeral(with string: String) {
+        // Tell ClipService to skip the next clipboard capture
+        AppEnvironment.current.clipService.skipNextCapture()
+        copyToPasteboard(with: string)
+        paste()
+
+        // Auto-clear pasteboard after configured delay
+        let clearDelay = AppEnvironment.current.defaults.integer(forKey: Constants.UserDefaults.ephemeralAutoClearSeconds)
+        if clearDelay > 0 {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(clearDelay)) {
+                // Only clear if the pasteboard still has what we put there
+                if NSPasteboard.general.string(forType: .clipyString) == string {
+                    AppEnvironment.current.clipService.skipNextCapture()
+                    NSPasteboard.general.clearContents()
+                }
+            }
+        }
+    }
+}
+
 // MARK: - Paste
 extension PasteService {
     func paste() {

--- a/Clipy/Sources/Services/ScriptExecutionService.swift
+++ b/Clipy/Sources/Services/ScriptExecutionService.swift
@@ -1,0 +1,147 @@
+//
+//  ScriptExecutionService.swift
+//
+//  Clipy
+//
+//  Executes shell scripts for script snippets with timeout and output capture.
+//
+
+import Foundation
+import Cocoa
+import os.log
+
+private let logger = Logger(subsystem: "com.clipy-app.Clipy", category: "ScriptExecution")
+
+struct ScriptExecutionService {
+
+    struct Result {
+        let output: String
+        let exitCode: Int32
+        let timedOut: Bool
+        let error: String?
+    }
+
+    /// Maximum output size in bytes (1 MB)
+    private static let maxOutputSize = 1_048_576
+
+    /// Execute a shell script and return the result via completion handler.
+    /// Reads the clipboard on the calling thread, then runs the script on a background thread.
+    /// Completion is called on the main queue.
+    static func execute(
+        script: String,
+        shell: String = CPYSnippet.defaultShell,
+        timeout: TimeInterval = TimeInterval(CPYSnippet.defaultTimeout),
+        environment: [String: String] = [:],
+        completion: @escaping (Result) -> Void
+    ) {
+        // Read clipboard eagerly on the calling thread to avoid DispatchQueue.main.sync deadlocks
+        let clipboard = NSPasteboard.general.string(forType: .string)
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let result = run(script: script, shell: shell, timeout: timeout, clipboard: clipboard, environment: environment)
+            DispatchQueue.main.async {
+                completion(result)
+            }
+        }
+    }
+
+    /// Synchronous script execution (called from background thread).
+    private static func run(
+        script: String,
+        shell: String,
+        timeout: TimeInterval,
+        clipboard: String?,
+        environment: [String: String]
+    ) -> Result {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: shell)
+        process.arguments = ["-c", script]
+        process.currentDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory())
+
+        var env = ProcessInfo.processInfo.environment
+        if let clipboard {
+            env["CLIPBOARD"] = clipboard
+        }
+        for (key, value) in environment {
+            env[key] = value
+        }
+        process.environment = env
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            logger.error("Failed to launch script: \(error.localizedDescription)")
+            return Result(output: "", exitCode: -1, timedOut: false, error: error.localizedDescription)
+        }
+
+        // Thread-safe timeout flag
+        let lock = NSLock()
+        var timedOut = false
+
+        let timer = DispatchSource.makeTimerSource(queue: .global())
+        timer.schedule(deadline: .now() + timeout)
+        timer.setEventHandler {
+            if process.isRunning {
+                lock.lock()
+                timedOut = true
+                lock.unlock()
+                process.terminate()
+                logger.warning("Script timed out after \(timeout)s")
+            }
+        }
+        timer.resume()
+
+        // Read pipe data concurrently BEFORE waitUntilExit to prevent kernel pipe buffer deadlock.
+        var stdoutData = Data()
+        var stderrData = Data()
+        let readGroup = DispatchGroup()
+
+        readGroup.enter()
+        DispatchQueue.global().async {
+            stdoutData = stdoutPipe.fileHandleForReading.readData(ofLength: maxOutputSize)
+            readGroup.leave()
+        }
+
+        readGroup.enter()
+        DispatchQueue.global().async {
+            stderrData = stderrPipe.fileHandleForReading.readData(ofLength: maxOutputSize)
+            readGroup.leave()
+        }
+
+        process.waitUntilExit()
+        readGroup.wait()
+        timer.cancel()
+
+        lock.lock()
+        let didTimeout = timedOut
+        lock.unlock()
+
+        let output = String(data: stdoutData, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let errorOutput = String(data: stderrData, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        if process.terminationStatus != 0 && !didTimeout {
+            logger.info("Script exited with code \(process.terminationStatus): \(errorOutput)")
+        }
+
+        return Result(
+            output: output,
+            exitCode: process.terminationStatus,
+            timedOut: didTimeout,
+            error: errorOutput.isEmpty ? nil : errorOutput
+        )
+    }
+
+    /// Environment variables available to script snippets (for UI hints).
+    static let availableEnvVars: [(name: String, desc: String)] = [
+        ("$CLIPBOARD", "Current clipboard text content"),
+        ("$HOME", "User home directory"),
+        ("$PATH", "System PATH (inherited)")
+    ]
+}

--- a/Clipy/Sources/Services/ScriptExecutionService.swift
+++ b/Clipy/Sources/Services/ScriptExecutionService.swift
@@ -91,7 +91,15 @@ struct ScriptExecutionService {
                 timedOut = true
                 lock.unlock()
                 process.terminate()
-                logger.warning("Script timed out after \(timeout)s")
+                logger.warning("Script timed out after \(timeout)s, sending SIGTERM")
+                // Escalate to SIGKILL if process doesn't exit within 2s
+                let pid = process.processIdentifier
+                DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
+                    if process.isRunning {
+                        kill(pid, SIGKILL)
+                        logger.warning("Script did not exit after SIGTERM, sent SIGKILL to pid \(pid)")
+                    }
+                }
             }
         }
         timer.resume()

--- a/Clipy/Sources/Services/ScriptExecutionService.swift
+++ b/Clipy/Sources/Services/ScriptExecutionService.swift
@@ -97,19 +97,20 @@ struct ScriptExecutionService {
         timer.resume()
 
         // Read pipe data concurrently BEFORE waitUntilExit to prevent kernel pipe buffer deadlock.
+        // Drain fully even past maxOutputSize so the child process can't block on a full pipe buffer.
         var stdoutData = Data()
         var stderrData = Data()
         let readGroup = DispatchGroup()
 
         readGroup.enter()
         DispatchQueue.global().async {
-            stdoutData = stdoutPipe.fileHandleForReading.readData(ofLength: maxOutputSize)
+            stdoutData = drainPipe(stdoutPipe.fileHandleForReading, limit: maxOutputSize)
             readGroup.leave()
         }
 
         readGroup.enter()
         DispatchQueue.global().async {
-            stderrData = stderrPipe.fileHandleForReading.readData(ofLength: maxOutputSize)
+            stderrData = drainPipe(stderrPipe.fileHandleForReading, limit: maxOutputSize)
             readGroup.leave()
         }
 
@@ -136,6 +137,24 @@ struct ScriptExecutionService {
             timedOut: didTimeout,
             error: errorOutput.isEmpty ? nil : errorOutput
         )
+    }
+
+    /// Drain a pipe fully to EOF, keeping only the first `limit` bytes.
+    /// Continues reading past the limit so the child process doesn't block on a full pipe buffer.
+    private static func drainPipe(_ handle: FileHandle, limit: Int) -> Data {
+        var collected = Data()
+        let chunkSize = 64 * 1024
+        var stored = 0
+        while true {
+            let chunk = handle.readData(ofLength: chunkSize)
+            if chunk.isEmpty { break }
+            if stored < limit {
+                let remaining = limit - stored
+                collected.append(chunk.prefix(remaining))
+                stored += min(chunk.count, remaining)
+            }
+        }
+        return collected
     }
 
     /// Environment variables available to script snippets (for UI hints).

--- a/Clipy/Sources/Snippets/CPYSnippetsEditorWindowController.swift
+++ b/Clipy/Sources/Snippets/CPYSnippetsEditorWindowController.swift
@@ -182,6 +182,9 @@ extension CPYSnippetsEditorWindowController {
                             let snippet = CPYSnippet()
                             snippet.title = snippetElement[Constants.Xml.titleElement].value ?? "untitled snippet"
                             snippet.content = snippetElement[Constants.Xml.contentElement].value ?? ""
+                            snippet.snippetType = Int(snippetElement["type"].value ?? "0") ?? 0
+                            snippet.scriptShell = snippetElement["shell"].value ?? CPYSnippet.defaultShell
+                            snippet.scriptTimeout = Int(snippetElement["timeout"].value ?? "\(CPYSnippet.defaultTimeout)") ?? CPYSnippet.defaultTimeout
                             snippet.index = snippetIndex
                             realm.transaction { folder.snippets.append(snippet) }
                             snippetIndex += 1
@@ -214,6 +217,11 @@ extension CPYSnippetsEditorWindowController {
                     let snippetElement = snippetsElement.addChild(name: Constants.Xml.snippetElement)
                     snippetElement.addChild(name: Constants.Xml.titleElement, value: snippet.title)
                     snippetElement.addChild(name: Constants.Xml.contentElement, value: snippet.content)
+                    if snippet.snippetType != CPYSnippet.SnippetType.plainText.rawValue {
+                        snippetElement.addChild(name: "type", value: "\(snippet.snippetType)")
+                        snippetElement.addChild(name: "shell", value: snippet.scriptShell)
+                        snippetElement.addChild(name: "timeout", value: "\(snippet.scriptTimeout)")
+                    }
                 }
         }
 

--- a/Clipy/Sources/Snippets/CPYSnippetsEditorWindowController.swift
+++ b/Clipy/Sources/Snippets/CPYSnippetsEditorWindowController.swift
@@ -185,6 +185,9 @@ extension CPYSnippetsEditorWindowController {
                             snippet.snippetType = Int(snippetElement["type"].value ?? "0") ?? 0
                             snippet.scriptShell = snippetElement["shell"].value ?? CPYSnippet.defaultShell
                             snippet.scriptTimeout = Int(snippetElement["timeout"].value ?? "\(CPYSnippet.defaultTimeout)") ?? CPYSnippet.defaultTimeout
+                            if let ephemeralValue = snippetElement["ephemeral"].value {
+                                snippet.isEphemeral = (ephemeralValue.lowercased() == "true" || ephemeralValue == "1")
+                            }
                             snippet.index = snippetIndex
                             realm.transaction { folder.snippets.append(snippet) }
                             snippetIndex += 1
@@ -221,6 +224,7 @@ extension CPYSnippetsEditorWindowController {
                         snippetElement.addChild(name: "type", value: "\(snippet.snippetType)")
                         snippetElement.addChild(name: "shell", value: snippet.scriptShell)
                         snippetElement.addChild(name: "timeout", value: "\(snippet.scriptTimeout)")
+                        snippetElement.addChild(name: "ephemeral", value: snippet.isEphemeral ? "true" : "false")
                     }
                 }
         }

--- a/Clipy/Sources/Snippets/ModernSnippetsEditor.swift
+++ b/Clipy/Sources/Snippets/ModernSnippetsEditor.swift
@@ -22,10 +22,17 @@ class SnippetsEditorViewModel: ObservableObject {
     @Published var selectedSnippetID: String?
     @Published var editingTitle = ""
     @Published var editingContent = ""
+    @Published var editingSnippetType = CPYSnippet.SnippetType.plainText.rawValue
+    @Published var editingScriptShell = CPYSnippet.defaultShell
+    @Published var editingScriptTimeout = CPYSnippet.defaultTimeout
+    @Published var editingIsEphemeral = true
     @Published var sidebarFilter = ""
     @Published var hasUnsavedChanges = false
     @Published var expandedFolderIDs = Set<String>()
     @Published var needsRefocus = false
+    @Published var scriptTestOutput: String?
+    @Published var isRunningTest = false
+    @Published var showingTemplates = false
 
     struct FolderItem: Identifiable, Hashable {
         let id: String
@@ -40,6 +47,12 @@ class SnippetsEditorViewModel: ObservableObject {
         var title: String
         var content: String
         var enabled: Bool
+        var snippetType: Int
+        var scriptShell: String
+        var scriptTimeout: Int
+        var isEphemeral: Bool
+
+        var isScript: Bool { snippetType == CPYSnippet.SnippetType.script.rawValue }
     }
 
     func load() {
@@ -51,7 +64,7 @@ class SnippetsEditorViewModel: ObservableObject {
             let snippets = folder.snippets
                 .sorted(byKeyPath: #keyPath(CPYSnippet.index), ascending: true)
                 .map { snippet in
-                    SnippetItem(id: snippet.identifier, title: snippet.title, content: snippet.content, enabled: snippet.enable)
+                    SnippetItem(id: snippet.identifier, title: snippet.title, content: snippet.content, enabled: snippet.enable, snippetType: snippet.snippetType, scriptShell: snippet.scriptShell, scriptTimeout: snippet.scriptTimeout, isEphemeral: snippet.isEphemeral)
                 }
             return FolderItem(id: folder.identifier, title: folder.title, enabled: folder.enable, isVault: folder.isVault, snippets: Array(snippets))
         }
@@ -70,6 +83,10 @@ class SnippetsEditorViewModel: ObservableObject {
                let snippet = folder.snippets.first(where: { $0.id == snippetID }) {
                 editingTitle = snippet.title
                 editingContent = snippet.content
+                editingSnippetType = snippet.snippetType
+                editingScriptShell = snippet.scriptShell
+                editingScriptTimeout = snippet.scriptTimeout
+                editingIsEphemeral = snippet.isEphemeral
                 hasUnsavedChanges = false
             }
         }
@@ -80,6 +97,11 @@ class SnippetsEditorViewModel: ObservableObject {
         selectedSnippetID = snippet.id
         editingTitle = snippet.title
         editingContent = snippet.content
+        editingSnippetType = snippet.snippetType
+        editingScriptShell = snippet.scriptShell
+        editingScriptTimeout = snippet.scriptTimeout
+        editingIsEphemeral = snippet.isEphemeral
+        scriptTestOutput = nil
         hasUnsavedChanges = false
     }
 
@@ -90,9 +112,67 @@ class SnippetsEditorViewModel: ObservableObject {
         realm.transaction {
             snippet.title = editingTitle
             snippet.content = editingContent
+            snippet.snippetType = editingSnippetType
+            snippet.scriptShell = editingScriptShell
+            snippet.scriptTimeout = editingScriptTimeout
+            snippet.isEphemeral = editingIsEphemeral
         }
         hasUnsavedChanges = false
         load()
+    }
+
+    func testRunScript() {
+        guard editingSnippetType == CPYSnippet.SnippetType.script.rawValue else { return }
+        isRunningTest = true
+        scriptTestOutput = nil
+        ScriptExecutionService.execute(
+            script: editingContent,
+            shell: editingScriptShell,
+            timeout: TimeInterval(editingScriptTimeout)
+        ) { [weak self] result in
+            self?.isRunningTest = false
+            if result.timedOut {
+                self?.scriptTestOutput = "[Timed out after \(self?.editingScriptTimeout ?? 10)s]"
+            } else if result.exitCode != 0 {
+                self?.scriptTestOutput = "[Exit \(result.exitCode)] \(result.error ?? "")\n\(result.output)"
+            } else {
+                self?.scriptTestOutput = result.output.isEmpty ? "[No output]" : result.output
+            }
+        }
+    }
+
+    func installTemplate(_ template: SnippetTemplate) {
+        // Install into the currently selected folder, or create a new one
+        let folderID: String
+        if let selected = selectedFolderID {
+            folderID = selected
+        } else {
+            let newFolder = CPYFolder.create()
+            newFolder.title = "Script Snippets"
+            newFolder.merge()
+            load()
+            folderID = newFolder.identifier
+            selectedFolderID = folderID
+        }
+
+        guard let realm = Realm.safeInstance() else { return }
+        guard let folder = realm.object(ofType: CPYFolder.self, forPrimaryKey: folderID) else { return }
+        let snippet = folder.createSnippet()
+        snippet.title = template.name
+        snippet.content = template.content
+        snippet.snippetType = CPYSnippet.SnippetType.script.rawValue
+        snippet.scriptShell = template.shell
+        snippet.scriptTimeout = template.timeout
+        folder.mergeSnippet(snippet)
+        load()
+
+        // Select the new snippet
+        if let folderItem = folders.first(where: { $0.id == folderID }),
+           let newSnippet = folderItem.snippets.last {
+            selectSnippet(newSnippet)
+            expandedFolderIDs.insert(folderID)
+        }
+        showingTemplates = false
     }
 
     func addFolder() {
@@ -133,6 +213,10 @@ class SnippetsEditorViewModel: ObservableObject {
             selectedSnippetID = nil
             editingTitle = ""
             editingContent = ""
+            editingSnippetType = CPYSnippet.SnippetType.plainText.rawValue
+            editingScriptShell = CPYSnippet.defaultShell
+            editingScriptTimeout = CPYSnippet.defaultTimeout
+            scriptTestOutput = nil
             hasUnsavedChanges = false
         }
         load()
@@ -331,6 +415,11 @@ class SnippetsEditorViewModel: ObservableObject {
                     let snippetElement = snippetsElement.addChild(name: Constants.Xml.snippetElement)
                     snippetElement.addChild(name: Constants.Xml.titleElement, value: snippet.title)
                     snippetElement.addChild(name: Constants.Xml.contentElement, value: snippet.content)
+                    if snippet.snippetType != CPYSnippet.SnippetType.plainText.rawValue {
+                        snippetElement.addChild(name: "type", value: "\(snippet.snippetType)")
+                        snippetElement.addChild(name: "shell", value: snippet.scriptShell)
+                        snippetElement.addChild(name: "timeout", value: "\(snippet.scriptTimeout)")
+                    }
                 }
         }
 
@@ -383,6 +472,9 @@ class SnippetsEditorViewModel: ObservableObject {
                             let snippet = CPYSnippet()
                             snippet.title = snippetElement[Constants.Xml.titleElement].value ?? "untitled snippet"
                             snippet.content = snippetElement[Constants.Xml.contentElement].value ?? ""
+                            snippet.snippetType = Int(snippetElement["type"].value ?? "0") ?? 0
+                            snippet.scriptShell = snippetElement["shell"].value ?? CPYSnippet.defaultShell
+                            snippet.scriptTimeout = Int(snippetElement["timeout"].value ?? "\(CPYSnippet.defaultTimeout)") ?? CPYSnippet.defaultTimeout
                             snippet.index = snippetIndex
                             folder.snippets.append(snippet)
                             snippetIndex += 1
@@ -426,6 +518,9 @@ struct ModernSnippetsEditorView: View {
                 viewModel.needsRefocus = false
                 sidebarFocused = true
             }
+        }
+        .sheet(isPresented: $viewModel.showingTemplates) {
+            SnippetTemplateGalleryView(viewModel: viewModel)
         }
     }
 
@@ -524,6 +619,10 @@ struct ModernSnippetsEditorView: View {
 
             Spacer()
 
+            SnippetToolbarButton(icon: "puzzlepiece.extension", help: "Templates") {
+                viewModel.showingTemplates = true
+            }
+
             SnippetToolbarButton(icon: "square.and.arrow.down", help: "Import") {
                 viewModel.importSnippets()
             }
@@ -558,84 +657,248 @@ struct ModernSnippetsEditorView: View {
     }
 
     private func editorHeader(snippet: SnippetsEditorViewModel.SnippetItem, folder: SnippetsEditorViewModel.FolderItem) -> some View {
-        HStack(spacing: 8) {
-            Image(systemName: "doc.text.fill")
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(.blue)
-                .frame(width: 26, height: 26)
-                .background(.blue.opacity(0.1))
-                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        VStack(spacing: 0) {
+            HStack(spacing: 8) {
+                Image(systemName: viewModel.editingSnippetType == CPYSnippet.SnippetType.script.rawValue ? "terminal.fill" : "doc.text.fill")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(viewModel.editingSnippetType == CPYSnippet.SnippetType.script.rawValue ? .green : .blue)
+                    .frame(width: 26, height: 26)
+                    .background((viewModel.editingSnippetType == CPYSnippet.SnippetType.script.rawValue ? SwiftUI.Color.green : SwiftUI.Color.blue).opacity(0.1))
+                    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
 
-            TextField("Snippet title", text: $viewModel.editingTitle)
-                .textFieldStyle(.plain)
-                .font(.system(size: 15, weight: .medium))
-                .onChange(of: viewModel.editingTitle) { _, _ in
+                TextField("Snippet title", text: $viewModel.editingTitle)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 15, weight: .medium))
+                    .onChange(of: viewModel.editingTitle) { _, _ in
+                        viewModel.hasUnsavedChanges = true
+                    }
+
+                Spacer()
+
+                // Type toggle
+                Picker("", selection: $viewModel.editingSnippetType) {
+                    Text("Text").tag(0)
+                    Text("Script").tag(1)
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 120)
+                .onChange(of: viewModel.editingSnippetType) { _, _ in
                     viewModel.hasUnsavedChanges = true
                 }
 
-            Spacer()
+                // Folder breadcrumb
+                HStack(spacing: 3) {
+                    Image(systemName: "folder.fill")
+                        .font(.system(size: 8))
+                    Text(folder.title)
+                        .font(.system(size: 9, weight: .medium))
+                }
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .background(.ultraThinMaterial)
+                .clipShape(Capsule())
+                .foregroundStyle(.secondary)
 
-            // Folder breadcrumb
-            HStack(spacing: 3) {
-                Image(systemName: "folder.fill")
-                    .font(.system(size: 8))
-                Text(folder.title)
-                    .font(.system(size: 9, weight: .medium))
+                // Enabled/disabled badge
+                Circle()
+                    .fill(snippet.enabled ? SwiftUI.Color.green : SwiftUI.Color.gray)
+                    .frame(width: 7, height: 7)
+                    .help(snippet.enabled ? "Enabled" : "Disabled")
             }
-            .padding(.horizontal, 7)
-            .padding(.vertical, 3)
-            .background(.ultraThinMaterial)
-            .clipShape(Capsule())
-            .foregroundStyle(.secondary)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
 
-            // Enabled/disabled badge
-            Circle()
-                .fill(snippet.enabled ? SwiftUI.Color.green : SwiftUI.Color.gray)
-                .frame(width: 7, height: 7)
-                .help(snippet.enabled ? "Enabled" : "Disabled")
+            // Script settings row (only visible in script mode)
+            if viewModel.editingSnippetType == CPYSnippet.SnippetType.script.rawValue {
+                HStack(spacing: 12) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "terminal")
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundStyle(.secondary)
+                        Picker("Shell", selection: $viewModel.editingScriptShell) {
+                            Text("/bin/bash").tag("/bin/bash")
+                            Text("/bin/zsh").tag("/bin/zsh")
+                            Text("/bin/sh").tag("/bin/sh")
+                            Text("/usr/bin/env python3").tag("/usr/bin/env python3")
+                        }
+                        .labelsHidden()
+                        .frame(width: 140)
+                        .onChange(of: viewModel.editingScriptShell) { _, _ in
+                            viewModel.hasUnsavedChanges = true
+                        }
+                    }
+
+                    HStack(spacing: 4) {
+                        Image(systemName: "clock")
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundStyle(.secondary)
+                        Picker("Timeout", selection: $viewModel.editingScriptTimeout) {
+                            Text("5s").tag(5)
+                            Text("10s").tag(10)
+                            Text("30s").tag(30)
+                            Text("60s").tag(60)
+                        }
+                        .labelsHidden()
+                        .frame(width: 70)
+                        .onChange(of: viewModel.editingScriptTimeout) { _, _ in
+                            viewModel.hasUnsavedChanges = true
+                        }
+                    }
+
+                    // Ephemeral toggle — output not saved to history
+                    Toggle(isOn: $viewModel.editingIsEphemeral) {
+                        HStack(spacing: 3) {
+                            Image(systemName: viewModel.editingIsEphemeral ? "eye.slash.fill" : "eye.fill")
+                                .font(.system(size: 9, weight: .medium))
+                            Text("Ephemeral")
+                                .font(.system(size: 10, weight: .medium))
+                        }
+                    }
+                    .toggleStyle(.switch)
+                    .controlSize(.mini)
+                    .help(viewModel.editingIsEphemeral ? "Output will NOT be saved to clipboard history (secure)" : "Output WILL be saved to clipboard history")
+                    .onChange(of: viewModel.editingIsEphemeral) { _, _ in
+                        viewModel.hasUnsavedChanges = true
+                    }
+
+                    Spacer()
+
+                    Button {
+                        viewModel.testRunScript()
+                    } label: {
+                        HStack(spacing: 4) {
+                            if viewModel.isRunningTest {
+                                ProgressView()
+                                    .controlSize(.mini)
+                            } else {
+                                Image(systemName: "play.fill")
+                                    .font(.system(size: 9))
+                            }
+                            Text("Test Run")
+                                .font(.system(size: 10, weight: .medium))
+                        }
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 4)
+                        .background(.green.opacity(0.12))
+                        .foregroundStyle(.green)
+                        .clipShape(Capsule())
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(viewModel.isRunningTest)
+                }
+                .padding(.horizontal, 16)
+                .padding(.bottom, 8)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
+        .animation(.easeOut(duration: 0.15), value: viewModel.editingSnippetType)
     }
 
     private var editorBody: some View {
-        TextEditor(text: $viewModel.editingContent)
-            .font(.system(size: 13, design: .monospaced))
-            .scrollContentBackground(.hidden)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .onChange(of: viewModel.editingContent) { _, _ in
-                viewModel.hasUnsavedChanges = true
+        VStack(spacing: 0) {
+            TextEditor(text: $viewModel.editingContent)
+                .font(.system(size: 13, design: .monospaced))
+                .scrollContentBackground(.hidden)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .onChange(of: viewModel.editingContent) { _, _ in
+                    viewModel.hasUnsavedChanges = true
+                }
+
+            // Script test output panel
+            if viewModel.editingSnippetType == CPYSnippet.SnippetType.script.rawValue, let output = viewModel.scriptTestOutput {
+                Divider().opacity(0.3)
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Image(systemName: "text.terminal")
+                            .font(.system(size: 9, weight: .semibold))
+                        Text("Test Output")
+                            .font(.system(size: 10, weight: .semibold))
+                        Spacer()
+                        Button {
+                            viewModel.scriptTestOutput = nil
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.system(size: 10))
+                                .foregroundStyle(.tertiary)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .foregroundStyle(.secondary)
+
+                    ScrollView {
+                        Text(output)
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundStyle(output.hasPrefix("[") ? .orange : .primary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .textSelection(.enabled)
+                    }
+                    .frame(maxHeight: 120)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(.black.opacity(0.04))
             }
+        }
     }
 
     private var variablesBar: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 5) {
-                Image(systemName: "percent")
-                    .font(.system(size: 9, weight: .semibold))
-                    .foregroundStyle(.tertiary)
-                    .padding(.trailing, 2)
+                if viewModel.editingSnippetType == CPYSnippet.SnippetType.script.rawValue {
+                    // Script mode: show environment variable hints
+                    Image(systemName: "terminal")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.green.opacity(0.6))
+                        .padding(.trailing, 2)
 
-                ForEach(SnippetVariableProcessor.availableVariables, id: \.name) { variable in
-                    Button {
-                        viewModel.editingContent += variable.name
-                        viewModel.hasUnsavedChanges = true
-                    } label: {
-                        Text(variable.name)
-                            .font(.system(size: 10, weight: .medium, design: .monospaced))
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
-                            .background(.white.opacity(0.06))
-                            .foregroundStyle(.secondary)
-                            .clipShape(Capsule())
-                            .overlay(
-                                Capsule()
-                                    .strokeBorder(.white.opacity(0.08), lineWidth: 0.5)
-                            )
+                    ForEach(ScriptExecutionService.availableEnvVars, id: \.name) { envVar in
+                        Button {
+                            viewModel.editingContent += envVar.name
+                            viewModel.hasUnsavedChanges = true
+                        } label: {
+                            Text(envVar.name)
+                                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 4)
+                                .background(.green.opacity(0.06))
+                                .foregroundStyle(.green.opacity(0.8))
+                                .clipShape(Capsule())
+                                .overlay(
+                                    Capsule()
+                                        .strokeBorder(.green.opacity(0.1), lineWidth: 0.5)
+                                )
+                        }
+                        .buttonStyle(.plain)
+                        .help(envVar.desc)
                     }
-                    .buttonStyle(.plain)
-                    .help(variable.desc)
+                } else {
+                    // Plain text mode: show variable placeholders
+                    Image(systemName: "percent")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                        .padding(.trailing, 2)
+
+                    ForEach(SnippetVariableProcessor.availableVariables, id: \.name) { variable in
+                        Button {
+                            viewModel.editingContent += variable.name
+                            viewModel.hasUnsavedChanges = true
+                        } label: {
+                            Text(variable.name)
+                                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 4)
+                                .background(.white.opacity(0.06))
+                                .foregroundStyle(.secondary)
+                                .clipShape(Capsule())
+                                .overlay(
+                                    Capsule()
+                                        .strokeBorder(.white.opacity(0.08), lineWidth: 0.5)
+                                )
+                        }
+                        .buttonStyle(.plain)
+                        .help(variable.desc)
+                    }
                 }
             }
             .padding(.horizontal, 14)
@@ -886,14 +1149,14 @@ struct SnippetItemRow: View {
         HStack(spacing: 6) {
             Spacer().frame(width: 14)
 
-            Image(systemName: snippet.enabled ? "doc.text.fill" : "doc.text")
+            Image(systemName: snippet.isScript ? (snippet.enabled ? "terminal.fill" : "terminal") : (snippet.enabled ? "doc.text.fill" : "doc.text"))
                 .font(.system(size: 10, weight: .medium))
-                .foregroundStyle(isSelected ? AnyShapeStyle(.white) : snippet.enabled ? AnyShapeStyle(.blue) : AnyShapeStyle(.quaternary))
+                .foregroundStyle(isSelected ? AnyShapeStyle(.white) : snippet.enabled ? AnyShapeStyle(snippet.isScript ? SwiftUI.Color.green : SwiftUI.Color.blue) : AnyShapeStyle(.quaternary))
                 .frame(width: 22, height: 22)
                 .background(
                     isSelected
                         ? AnyShapeStyle(.white.opacity(0.15))
-                        : AnyShapeStyle(snippet.enabled ? SwiftUI.Color.blue.opacity(0.08) : SwiftUI.Color.clear)
+                        : AnyShapeStyle(snippet.enabled ? (snippet.isScript ? SwiftUI.Color.green : SwiftUI.Color.blue).opacity(0.08) : SwiftUI.Color.clear)
                 )
                 .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
 
@@ -1051,5 +1314,98 @@ extension ModernSnippetsWindowController: NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
         NotificationCenter.default.post(name: Notification.Name(rawValue: Constants.Notification.closeSnippetEditor), object: nil)
         NSApp.deactivate()
+    }
+}
+
+// MARK: - Snippet Template Gallery
+
+struct SnippetTemplateGalleryView: View {
+    @ObservedObject var viewModel: SnippetsEditorViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Image(systemName: "puzzlepiece.extension.fill")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(.blue)
+                Text("Script Templates")
+                    .font(.system(size: 16, weight: .semibold))
+                Spacer()
+                Button { viewModel.showingTemplates = false } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 16))
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(16)
+
+            Divider().opacity(0.3)
+
+            // Template list grouped by category
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    ForEach(SnippetTemplateLibrary.categories, id: \.self) { category in
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(category.uppercased())
+                                .font(.system(size: 10, weight: .bold, design: .rounded))
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, 4)
+
+                            ForEach(SnippetTemplateLibrary.templates(in: category)) { template in
+                                templateRow(template)
+                            }
+                        }
+                    }
+                }
+                .padding(16)
+            }
+        }
+        .frame(width: 480, height: 440)
+        .background(.regularMaterial)
+    }
+
+    private func templateRow(_ template: SnippetTemplate) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: template.icon)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.green)
+                .frame(width: 28, height: 28)
+                .background(SwiftUI.Color.green.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(template.name)
+                    .font(.system(size: 12, weight: .medium))
+                Text(template.description)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            Spacer()
+
+            Button {
+                viewModel.installTemplate(template)
+            } label: {
+                HStack(spacing: 3) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 9, weight: .bold))
+                    Text("Add")
+                        .font(.system(size: 10, weight: .medium))
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(.blue.opacity(0.12))
+                .foregroundStyle(.blue)
+                .clipShape(Capsule())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(.white.opacity(0.03))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
     }
 }

--- a/Clipy/Sources/Snippets/ModernSnippetsEditor.swift
+++ b/Clipy/Sources/Snippets/ModernSnippetsEditor.swift
@@ -424,6 +424,7 @@ extension SnippetsEditorViewModel {
                         snippetElement.addChild(name: "type", value: "\(snippet.snippetType)")
                         snippetElement.addChild(name: "shell", value: snippet.scriptShell)
                         snippetElement.addChild(name: "timeout", value: "\(snippet.scriptTimeout)")
+                        snippetElement.addChild(name: "ephemeral", value: snippet.isEphemeral ? "true" : "false")
                     }
                 }
         }
@@ -480,6 +481,9 @@ extension SnippetsEditorViewModel {
                             snippet.snippetType = Int(snippetElement["type"].value ?? "0") ?? 0
                             snippet.scriptShell = snippetElement["shell"].value ?? CPYSnippet.defaultShell
                             snippet.scriptTimeout = Int(snippetElement["timeout"].value ?? "\(CPYSnippet.defaultTimeout)") ?? CPYSnippet.defaultTimeout
+                            if let ephemeralValue = snippetElement["ephemeral"].value {
+                                snippet.isEphemeral = (ephemeralValue.lowercased() == "true" || ephemeralValue == "1")
+                            }
                             snippet.index = snippetIndex
                             folder.snippets.append(snippet)
                             snippetIndex += 1

--- a/Clipy/Sources/Snippets/ModernSnippetsEditor.swift
+++ b/Clipy/Sources/Snippets/ModernSnippetsEditor.swift
@@ -141,8 +141,11 @@ class SnippetsEditorViewModel: ObservableObject {
         }
     }
 
-    func installTemplate(_ template: SnippetTemplate) {
-        // Install into the currently selected folder, or create a new one
+    /// Template pending parameter configuration (shown in config sheet).
+    @Published var pendingTemplate: SnippetTemplate?
+    @Published var pendingTemplateValues: [String: String] = [:]
+
+    func installTemplate(_ template: SnippetTemplate, values: [String: String] = [:]) {
         let folderID: String
         if let selected = selectedFolderID {
             folderID = selected
@@ -159,7 +162,7 @@ class SnippetsEditorViewModel: ObservableObject {
         guard let folder = realm.object(ofType: CPYFolder.self, forPrimaryKey: folderID) else { return }
         let snippet = folder.createSnippet()
         snippet.title = template.name
-        snippet.content = template.content
+        snippet.content = template.resolvedContent(with: values)
         snippet.snippetType = CPYSnippet.SnippetType.script.rawValue
         snippet.scriptShell = template.shell
         snippet.scriptTimeout = template.timeout
@@ -1324,7 +1327,22 @@ struct SnippetTemplateGalleryView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Header
+            if let template = viewModel.pendingTemplate {
+                // Parameter configuration form
+                templateConfigView(template)
+            } else {
+                // Template browser
+                templateBrowser
+            }
+        }
+        .frame(width: 480, height: 440)
+        .background(.regularMaterial)
+    }
+
+    // MARK: - Template Browser
+
+    private var templateBrowser: some View {
+        VStack(spacing: 0) {
             HStack {
                 Image(systemName: "puzzlepiece.extension.fill")
                     .font(.system(size: 16, weight: .medium))
@@ -1343,7 +1361,6 @@ struct SnippetTemplateGalleryView: View {
 
             Divider().opacity(0.3)
 
-            // Template list grouped by category
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
                     ForEach(SnippetTemplateLibrary.categories, id: \.self) { category in
@@ -1362,8 +1379,6 @@ struct SnippetTemplateGalleryView: View {
                 .padding(16)
             }
         }
-        .frame(width: 480, height: 440)
-        .background(.regularMaterial)
     }
 
     private func templateRow(_ template: SnippetTemplate) -> some View {
@@ -1376,8 +1391,19 @@ struct SnippetTemplateGalleryView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(template.name)
-                    .font(.system(size: 12, weight: .medium))
+                HStack(spacing: 4) {
+                    Text(template.name)
+                        .font(.system(size: 12, weight: .medium))
+                    if template.hasParameters {
+                        Text("\(template.parameters.count) fields")
+                            .font(.system(size: 8, weight: .bold, design: .rounded))
+                            .foregroundStyle(.blue)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(SwiftUI.Color.blue.opacity(0.1))
+                            .clipShape(Capsule())
+                    }
+                }
                 Text(template.description)
                     .font(.system(size: 10))
                     .foregroundStyle(.secondary)
@@ -1387,12 +1413,23 @@ struct SnippetTemplateGalleryView: View {
             Spacer()
 
             Button {
-                viewModel.installTemplate(template)
+                if template.hasParameters {
+                    // Show config form
+                    var defaults = [String: String]()
+                    for param in template.parameters {
+                        defaults[param.key] = param.defaultValue
+                    }
+                    viewModel.pendingTemplateValues = defaults
+                    viewModel.pendingTemplate = template
+                } else {
+                    // Install directly
+                    viewModel.installTemplate(template)
+                }
             } label: {
                 HStack(spacing: 3) {
-                    Image(systemName: "plus")
+                    Image(systemName: template.hasParameters ? "slider.horizontal.3" : "plus")
                         .font(.system(size: 9, weight: .bold))
-                    Text("Add")
+                    Text(template.hasParameters ? "Configure" : "Add")
                         .font(.system(size: 10, weight: .medium))
                 }
                 .padding(.horizontal, 10)
@@ -1407,5 +1444,115 @@ struct SnippetTemplateGalleryView: View {
         .padding(.vertical, 8)
         .background(.white.opacity(0.03))
         .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    // MARK: - Parameter Configuration Form
+
+    private func templateConfigView(_ template: SnippetTemplate) -> some View {
+        VStack(spacing: 0) {
+            // Header with back button
+            HStack(spacing: 10) {
+                Button {
+                    viewModel.pendingTemplate = nil
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+
+                Image(systemName: template.icon)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.green)
+
+                Text(template.name)
+                    .font(.system(size: 15, weight: .semibold))
+
+                Spacer()
+
+                Button { viewModel.showingTemplates = false; viewModel.pendingTemplate = nil } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 16))
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(16)
+
+            Divider().opacity(0.3)
+
+            // Form fields
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text(template.description)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .padding(.bottom, 4)
+
+                    ForEach(template.parameters) { param in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(param.label)
+                                .font(.system(size: 11, weight: .medium))
+
+                            TextField(param.placeholder, text: Binding(
+                                get: { viewModel.pendingTemplateValues[param.key] ?? param.defaultValue },
+                                set: { viewModel.pendingTemplateValues[param.key] = $0 }
+                            ))
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(size: 12, design: .monospaced))
+                        }
+                    }
+
+                    // Preview of resolved script
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Preview")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(.secondary)
+
+                        Text(template.resolvedContent(with: viewModel.pendingTemplateValues))
+                            .font(.system(size: 10, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(12)
+                            .padding(8)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(.black.opacity(0.05))
+                            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                    }
+                    .padding(.top, 4)
+                }
+                .padding(16)
+            }
+
+            Divider().opacity(0.3)
+
+            // Footer with Create button
+            HStack {
+                Text("Recommended: place in a Vault folder for Touch ID protection")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.tertiary)
+
+                Spacer()
+
+                Button {
+                    viewModel.installTemplate(template, values: viewModel.pendingTemplateValues)
+                    viewModel.pendingTemplate = nil
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "plus.circle.fill")
+                            .font(.system(size: 11))
+                        Text("Create Snippet")
+                            .font(.system(size: 12, weight: .medium))
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 7)
+                    .background(.blue)
+                    .foregroundStyle(.white)
+                    .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+        }
     }
 }

--- a/Clipy/Sources/Snippets/ModernSnippetsEditor.swift
+++ b/Clipy/Sources/Snippets/ModernSnippetsEditor.swift
@@ -396,8 +396,10 @@ class SnippetsEditorViewModel: ObservableObject {
         }
     }
 
-    // MARK: - Import / Export
+}
 
+// MARK: - Import / Export
+extension SnippetsEditorViewModel {
     func exportSnippets() {
         let xmlDocument = AEXMLDocument()
         let rootElement = xmlDocument.addChild(name: Constants.Xml.rootElement)

--- a/Clipy/Sources/Snippets/ModernSnippetsEditor.swift
+++ b/Clipy/Sources/Snippets/ModernSnippetsEditor.swift
@@ -528,7 +528,10 @@ struct ModernSnippetsEditorView: View {
                 sidebarFocused = true
             }
         }
-        .sheet(isPresented: $viewModel.showingTemplates) {
+        .sheet(isPresented: $viewModel.showingTemplates, onDismiss: {
+            viewModel.pendingTemplate = nil
+            viewModel.pendingTemplateValues = [:]
+        }) {
             SnippetTemplateGalleryView(viewModel: viewModel)
         }
     }
@@ -728,7 +731,7 @@ struct ModernSnippetsEditorView: View {
                             Text("/bin/bash").tag("/bin/bash")
                             Text("/bin/zsh").tag("/bin/zsh")
                             Text("/bin/sh").tag("/bin/sh")
-                            Text("/usr/bin/env python3").tag("/usr/bin/env python3")
+                            Text("/usr/bin/python3").tag("/usr/bin/python3")
                         }
                         .labelsHidden()
                         .frame(width: 140)

--- a/Clipy/Sources/Snippets/SnippetTemplates.swift
+++ b/Clipy/Sources/Snippets/SnippetTemplates.swift
@@ -1,0 +1,308 @@
+//
+//  SnippetTemplates.swift
+//
+//  Clipy
+//
+//  Built-in script snippet templates for common workflows.
+//
+
+import Foundation
+
+struct SnippetTemplate: Identifiable {
+    let id = UUID().uuidString
+    let name: String
+    let description: String
+    let category: String
+    let icon: String
+    let shell: String
+    let content: String
+    let timeout: Int
+}
+
+struct SnippetTemplateLibrary {
+
+    static let templates: [SnippetTemplate] = [
+        // MARK: - AWS
+        // Each template uses hardcoded config — edit PROFILE/SECRET_NAME after adding.
+        // Recommended: place AWS snippets in a Vault folder (Touch ID protected).
+        SnippetTemplate(
+            name: "AWS SSO Credentials (env vars)",
+            description: "Auto-refreshes SSO session and pastes credentials as export statements. Edit PROFILE below.",
+            category: "AWS",
+            icon: "cloud.fill",
+            shell: "/bin/bash",
+            content: """
+            #!/bin/bash
+            # ✏️ Set your AWS profile name here:
+            PROFILE="your-profile-name"
+
+            # Auto-authenticate if session expired
+            if ! aws sts get-caller-identity --profile "$PROFILE" &>/dev/null; then
+                aws sso login --profile "$PROFILE" >&2
+            fi
+
+            # Export credentials as env vars
+            aws configure export-credentials --profile "$PROFILE" --format env 2>/dev/null || \\
+                echo "# Failed to get credentials for profile: $PROFILE"
+            """,
+            timeout: 30
+        ),
+
+        SnippetTemplate(
+            name: "AWS Secret Fetch",
+            description: "Fetches a secret from AWS Secrets Manager by name. Edit PROFILE and SECRET_NAME below.",
+            category: "AWS",
+            icon: "lock.shield.fill",
+            shell: "/bin/bash",
+            content: """
+            #!/bin/bash
+            # ✏️ Configure your AWS profile and secret:
+            PROFILE="your-profile-name"
+            SECRET_NAME="your/secret/name"
+
+            # Auto-authenticate if session expired
+            if ! aws sts get-caller-identity --profile "$PROFILE" &>/dev/null; then
+                aws sso login --profile "$PROFILE" >&2
+            fi
+
+            # Fetch the secret value
+            aws secretsmanager get-secret-value \\
+                --profile "$PROFILE" \\
+                --secret-id "$SECRET_NAME" \\
+                --query 'SecretString' \\
+                --output text 2>/dev/null || \\
+                echo "[Failed to fetch secret: $SECRET_NAME]"
+            """,
+            timeout: 15
+        ),
+
+        SnippetTemplate(
+            name: "AWS Secret Field (JSON key)",
+            description: "Fetches a JSON secret and extracts a specific field. Edit PROFILE, SECRET_NAME, and FIELD.",
+            category: "AWS",
+            icon: "key.fill",
+            shell: "/bin/bash",
+            content: """
+            #!/bin/bash
+            # ✏️ Configure your AWS profile, secret, and JSON field:
+            PROFILE="your-profile-name"
+            SECRET_NAME="your/secret/name"
+            FIELD="password"
+
+            # Auto-authenticate if session expired
+            if ! aws sts get-caller-identity --profile "$PROFILE" &>/dev/null; then
+                aws sso login --profile "$PROFILE" >&2
+            fi
+
+            # Fetch secret and extract the field
+            aws secretsmanager get-secret-value \\
+                --profile "$PROFILE" \\
+                --secret-id "$SECRET_NAME" \\
+                --query 'SecretString' \\
+                --output text 2>/dev/null | \\
+                python3 -c "import sys,json; print(json.load(sys.stdin)['$FIELD'])" 2>/dev/null || \\
+                echo "[Failed to fetch field '$FIELD' from secret: $SECRET_NAME]"
+            """,
+            timeout: 15
+        ),
+
+        SnippetTemplate(
+            name: "AWS SSM Parameter",
+            description: "Fetches a parameter from AWS Systems Manager Parameter Store. Edit PROFILE and PARAM_NAME.",
+            category: "AWS",
+            icon: "slider.horizontal.3",
+            shell: "/bin/bash",
+            content: """
+            #!/bin/bash
+            # ✏️ Configure your AWS profile and parameter path:
+            PROFILE="your-profile-name"
+            PARAM_NAME="/your/parameter/path"
+
+            # Auto-authenticate if session expired
+            if ! aws sts get-caller-identity --profile "$PROFILE" &>/dev/null; then
+                aws sso login --profile "$PROFILE" >&2
+            fi
+
+            # Fetch the parameter value (with decryption for SecureString)
+            aws ssm get-parameter \\
+                --profile "$PROFILE" \\
+                --name "$PARAM_NAME" \\
+                --with-decryption \\
+                --query 'Parameter.Value' \\
+                --output text 2>/dev/null || \\
+                echo "[Failed to fetch parameter: $PARAM_NAME]"
+            """,
+            timeout: 15
+        ),
+
+        // MARK: - JSON
+        SnippetTemplate(
+            name: "JSON Pretty Print",
+            description: "Format clipboard JSON with indentation.",
+            category: "Format",
+            icon: "curlybraces",
+
+            shell: "/bin/bash",
+            content: """
+            #!/bin/bash
+            echo "$CLIPBOARD" | python3 -m json.tool 2>/dev/null || echo "$CLIPBOARD"
+            """,
+            timeout: 5
+        ),
+
+        SnippetTemplate(
+            name: "JSON Minify",
+            description: "Compress clipboard JSON to a single line.",
+            category: "Format",
+            icon: "curlybraces",
+
+            shell: "/bin/bash",
+            content: """
+            #!/bin/bash
+            echo "$CLIPBOARD" | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin),separators=(',',':')))" 2>/dev/null || echo "$CLIPBOARD"
+            """,
+            timeout: 5
+        ),
+
+        // MARK: - Encoding
+        SnippetTemplate(
+            name: "Base64 Encode",
+            description: "Base64-encode clipboard content.",
+            category: "Encode",
+            icon: "lock.fill",
+
+            shell: "/bin/bash",
+            content: """
+            #!/bin/bash
+            echo -n "$CLIPBOARD" | base64
+            """,
+            timeout: 5
+        ),
+
+        SnippetTemplate(
+            name: "Base64 Decode",
+            description: "Base64-decode clipboard content.",
+            category: "Encode",
+            icon: "lock.open.fill",
+
+            shell: "/bin/bash",
+            content: """
+            #!/bin/bash
+            echo -n "$CLIPBOARD" | base64 -d 2>/dev/null || echo "[Invalid base64]"
+            """,
+            timeout: 5
+        ),
+
+        SnippetTemplate(
+            name: "URL Encode",
+            description: "Percent-encode clipboard text for use in URLs.",
+            category: "Encode",
+            icon: "link",
+
+            shell: "/bin/bash",
+            content: """
+            #!/bin/bash
+            python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.stdin.read().strip()))" <<< "$CLIPBOARD"
+            """,
+            timeout: 5
+        ),
+
+        // MARK: - JWT
+        SnippetTemplate(
+            name: "JWT Decode Payload",
+            description: "Decode a JWT token and extract the payload.",
+            category: "Security",
+            icon: "key.horizontal.fill",
+
+            shell: "/bin/bash",
+            content: """
+            #!/bin/bash
+            # Extract and decode JWT payload (second segment)
+            PAYLOAD=$(echo -n "$CLIPBOARD" | cut -d. -f2)
+            # Add padding if needed
+            MOD=$((${#PAYLOAD} % 4))
+            if [ $MOD -eq 2 ]; then PAYLOAD="${PAYLOAD}=="
+            elif [ $MOD -eq 3 ]; then PAYLOAD="${PAYLOAD}="
+            fi
+            echo -n "$PAYLOAD" | base64 -d 2>/dev/null | python3 -m json.tool 2>/dev/null || echo "[Invalid JWT]"
+            """,
+            timeout: 5
+        ),
+
+        // MARK: - Conversion
+        SnippetTemplate(
+            name: "Epoch to Date",
+            description: "Convert a Unix timestamp in clipboard to human-readable date.",
+            category: "Convert",
+            icon: "clock.fill",
+
+            shell: "/bin/bash",
+            content: """
+            #!/bin/bash
+            TIMESTAMP="$CLIPBOARD"
+            # Handle millisecond timestamps
+            if [ ${#TIMESTAMP} -gt 10 ]; then
+                TIMESTAMP=$((TIMESTAMP / 1000))
+            fi
+            date -r "$TIMESTAMP" "+%Y-%m-%d %H:%M:%S %Z" 2>/dev/null || echo "[Invalid timestamp]"
+            """,
+            timeout: 5
+        ),
+
+        SnippetTemplate(
+            name: "Markdown to HTML",
+            description: "Convert Markdown clipboard content to HTML (requires python3-markdown).",
+            category: "Convert",
+            icon: "doc.richtext.fill",
+
+            shell: "/bin/bash",
+            content: """
+            #!/bin/bash
+            echo "$CLIPBOARD" | python3 -c "
+            import sys
+            try:
+                import markdown
+                print(markdown.markdown(sys.stdin.read()))
+            except ImportError:
+                print('[Install python3-markdown: pip3 install markdown]')
+            " 2>/dev/null
+            """,
+            timeout: 5
+        ),
+
+        // MARK: - Generators
+        SnippetTemplate(
+            name: "Generate UUID",
+            description: "Generate a fresh UUID v4.",
+            category: "Generate",
+            icon: "number",
+
+            shell: "/bin/bash",
+            content: """
+            #!/bin/bash
+            uuidgen | tr '[:upper:]' '[:lower:]'
+            """,
+            timeout: 5
+        ),
+
+        SnippetTemplate(
+            name: "Generate Password",
+            description: "Generate a random 24-character password.",
+            category: "Generate",
+            icon: "key.fill",
+
+            shell: "/bin/bash",
+            content: """
+            #!/bin/bash
+            LC_ALL=C tr -dc 'A-Za-z0-9!@#$%^&*' < /dev/urandom | head -c 24
+            """,
+            timeout: 5
+        ),
+    ]
+
+    static let categories: [String] = Array(Set(templates.map(\.category))).sorted()
+
+    static func templates(in category: String) -> [SnippetTemplate] {
+        templates.filter { $0.category == category }
+    }
+}

--- a/Clipy/Sources/Snippets/SnippetTemplates.swift
+++ b/Clipy/Sources/Snippets/SnippetTemplates.swift
@@ -8,6 +8,14 @@
 
 import Foundation
 
+struct TemplateParameter: Identifiable {
+    let id = UUID().uuidString
+    let key: String          // placeholder in script, e.g. "{{PROFILE}}"
+    let label: String        // shown in form, e.g. "AWS Profile"
+    let placeholder: String  // hint text, e.g. "my-sso-profile"
+    let defaultValue: String
+}
+
 struct SnippetTemplate: Identifiable {
     let id = UUID().uuidString
     let name: String
@@ -17,55 +25,76 @@ struct SnippetTemplate: Identifiable {
     let shell: String
     let content: String
     let timeout: Int
+    let parameters: [TemplateParameter]
+
+    init(name: String, description: String, category: String, icon: String,
+         shell: String, content: String, timeout: Int,
+         parameters: [TemplateParameter] = []) {
+        self.name = name
+        self.description = description
+        self.category = category
+        self.icon = icon
+        self.shell = shell
+        self.content = content
+        self.timeout = timeout
+        self.parameters = parameters
+    }
+
+    /// Replace {{KEY}} placeholders in content with provided values.
+    func resolvedContent(with values: [String: String]) -> String {
+        var result = content
+        for param in parameters {
+            let value = values[param.key] ?? param.defaultValue
+            result = result.replacingOccurrences(of: "{{\(param.key)}}", with: value)
+        }
+        return result
+    }
+
+    var hasParameters: Bool { !parameters.isEmpty }
 }
 
 struct SnippetTemplateLibrary {
 
     static let templates: [SnippetTemplate] = [
         // MARK: - AWS
-        // Each template uses hardcoded config — edit PROFILE/SECRET_NAME after adding.
-        // Recommended: place AWS snippets in a Vault folder (Touch ID protected).
         SnippetTemplate(
-            name: "AWS SSO Credentials (env vars)",
-            description: "Auto-refreshes SSO session and pastes credentials as export statements. Edit PROFILE below.",
+            name: "AWS SSO Credentials",
+            description: "Auto-refreshes SSO session and pastes credentials as export statements.",
             category: "AWS",
             icon: "cloud.fill",
             shell: "/bin/bash",
             content: """
             #!/bin/bash
-            # ✏️ Set your AWS profile name here:
-            PROFILE="your-profile-name"
+            PROFILE="{{PROFILE}}"
 
-            # Auto-authenticate if session expired
             if ! aws sts get-caller-identity --profile "$PROFILE" &>/dev/null; then
                 aws sso login --profile "$PROFILE" >&2
             fi
 
-            # Export credentials as env vars
             aws configure export-credentials --profile "$PROFILE" --format env 2>/dev/null || \\
                 echo "# Failed to get credentials for profile: $PROFILE"
             """,
-            timeout: 30
+            timeout: 30,
+            parameters: [
+                TemplateParameter(key: "PROFILE", label: "AWS Profile", placeholder: "my-sso-profile", defaultValue: "default"),
+            ]
         ),
 
         SnippetTemplate(
             name: "AWS Secret Fetch",
-            description: "Fetches a secret from AWS Secrets Manager by name. Edit PROFILE and SECRET_NAME below.",
+            description: "Fetches a secret value from AWS Secrets Manager.",
             category: "AWS",
             icon: "lock.shield.fill",
             shell: "/bin/bash",
             content: """
             #!/bin/bash
-            # ✏️ Configure your AWS profile and secret:
-            PROFILE="your-profile-name"
-            SECRET_NAME="your/secret/name"
+            PROFILE="{{PROFILE}}"
+            SECRET_NAME="{{SECRET_NAME}}"
 
-            # Auto-authenticate if session expired
             if ! aws sts get-caller-identity --profile "$PROFILE" &>/dev/null; then
                 aws sso login --profile "$PROFILE" >&2
             fi
 
-            # Fetch the secret value
             aws secretsmanager get-secret-value \\
                 --profile "$PROFILE" \\
                 --secret-id "$SECRET_NAME" \\
@@ -73,28 +102,29 @@ struct SnippetTemplateLibrary {
                 --output text 2>/dev/null || \\
                 echo "[Failed to fetch secret: $SECRET_NAME]"
             """,
-            timeout: 15
+            timeout: 15,
+            parameters: [
+                TemplateParameter(key: "PROFILE", label: "AWS Profile", placeholder: "my-sso-profile", defaultValue: "default"),
+                TemplateParameter(key: "SECRET_NAME", label: "Secret Name", placeholder: "prod/database/password", defaultValue: ""),
+            ]
         ),
 
         SnippetTemplate(
             name: "AWS Secret Field (JSON key)",
-            description: "Fetches a JSON secret and extracts a specific field. Edit PROFILE, SECRET_NAME, and FIELD.",
+            description: "Fetches a JSON secret and extracts a specific field by key.",
             category: "AWS",
             icon: "key.fill",
             shell: "/bin/bash",
             content: """
             #!/bin/bash
-            # ✏️ Configure your AWS profile, secret, and JSON field:
-            PROFILE="your-profile-name"
-            SECRET_NAME="your/secret/name"
-            FIELD="password"
+            PROFILE="{{PROFILE}}"
+            SECRET_NAME="{{SECRET_NAME}}"
+            FIELD="{{FIELD}}"
 
-            # Auto-authenticate if session expired
             if ! aws sts get-caller-identity --profile "$PROFILE" &>/dev/null; then
                 aws sso login --profile "$PROFILE" >&2
             fi
 
-            # Fetch secret and extract the field
             aws secretsmanager get-secret-value \\
                 --profile "$PROFILE" \\
                 --secret-id "$SECRET_NAME" \\
@@ -103,27 +133,29 @@ struct SnippetTemplateLibrary {
                 python3 -c "import sys,json; print(json.load(sys.stdin)['$FIELD'])" 2>/dev/null || \\
                 echo "[Failed to fetch field '$FIELD' from secret: $SECRET_NAME]"
             """,
-            timeout: 15
+            timeout: 15,
+            parameters: [
+                TemplateParameter(key: "PROFILE", label: "AWS Profile", placeholder: "my-sso-profile", defaultValue: "default"),
+                TemplateParameter(key: "SECRET_NAME", label: "Secret Name", placeholder: "prod/database/credentials", defaultValue: ""),
+                TemplateParameter(key: "FIELD", label: "JSON Field", placeholder: "password", defaultValue: "password"),
+            ]
         ),
 
         SnippetTemplate(
             name: "AWS SSM Parameter",
-            description: "Fetches a parameter from AWS Systems Manager Parameter Store. Edit PROFILE and PARAM_NAME.",
+            description: "Fetches a parameter from AWS Systems Manager Parameter Store.",
             category: "AWS",
             icon: "slider.horizontal.3",
             shell: "/bin/bash",
             content: """
             #!/bin/bash
-            # ✏️ Configure your AWS profile and parameter path:
-            PROFILE="your-profile-name"
-            PARAM_NAME="/your/parameter/path"
+            PROFILE="{{PROFILE}}"
+            PARAM_NAME="{{PARAM_NAME}}"
 
-            # Auto-authenticate if session expired
             if ! aws sts get-caller-identity --profile "$PROFILE" &>/dev/null; then
                 aws sso login --profile "$PROFILE" >&2
             fi
 
-            # Fetch the parameter value (with decryption for SecureString)
             aws ssm get-parameter \\
                 --profile "$PROFILE" \\
                 --name "$PARAM_NAME" \\
@@ -132,7 +164,11 @@ struct SnippetTemplateLibrary {
                 --output text 2>/dev/null || \\
                 echo "[Failed to fetch parameter: $PARAM_NAME]"
             """,
-            timeout: 15
+            timeout: 15,
+            parameters: [
+                TemplateParameter(key: "PROFILE", label: "AWS Profile", placeholder: "my-sso-profile", defaultValue: "default"),
+                TemplateParameter(key: "PARAM_NAME", label: "Parameter Path", placeholder: "/app/config/db-host", defaultValue: ""),
+            ]
         ),
 
         // MARK: - JSON

--- a/Clipy/Sources/Utility/CPYUtilities.swift
+++ b/Clipy/Sources/Utility/CPYUtilities.swift
@@ -57,6 +57,7 @@ final class CPYUtilities {
         defaultValues.updateValue(NSNumber(value: true), forKey: Constants.UserDefaults.copySameHistory)
         defaultValues.updateValue(NSNumber(value: true), forKey: Constants.UserDefaults.showColorPreviewInTheMenu)
         defaultValues.updateValue(NSNumber(value: false), forKey: Constants.UserDefaults.clearHistoryIncludesPinned)
+        defaultValues.updateValue(NSNumber(value: 30), forKey: Constants.UserDefaults.ephemeralAutoClearSeconds)
 
         /* Snippets */
         defaultValues.updateValue(NSNumber(value: true), forKey: Constants.Snippets.useModernPicker)

--- a/Clipy/Sources/Views/SnippetPicker/SnippetPickerPanel.swift
+++ b/Clipy/Sources/Views/SnippetPicker/SnippetPickerPanel.swift
@@ -28,13 +28,21 @@ struct PickerSnippet: Identifiable, Hashable {
     let content: String
     let folderTitle: String
     let hasVariables: Bool
+    let isScript: Bool
+    let scriptShell: String
+    let scriptTimeout: Int
+    let isEphemeral: Bool
 
-    init(id: String, title: String, content: String, folderTitle: String) {
+    init(id: String, title: String, content: String, folderTitle: String, snippetType: Int = CPYSnippet.SnippetType.plainText.rawValue, scriptShell: String = CPYSnippet.defaultShell, scriptTimeout: Int = CPYSnippet.defaultTimeout, isEphemeral: Bool = true) {
         self.id = id
         self.title = title
         self.content = content
         self.folderTitle = folderTitle
-        self.hasVariables = content.contains("%") && SnippetVariableProcessor.availableVariables.contains { content.contains($0.name) }
+        self.isScript = snippetType == CPYSnippet.SnippetType.script.rawValue
+        self.scriptShell = scriptShell
+        self.scriptTimeout = scriptTimeout
+        self.isEphemeral = isEphemeral
+        self.hasVariables = !self.isScript && content.contains("%") && SnippetVariableProcessor.availableVariables.contains { content.contains($0.name) }
     }
 
     var preview: String {
@@ -116,7 +124,11 @@ class SnippetPickerViewModel: ObservableObject {
                         id: snippet.identifier,
                         title: snippet.title,
                         content: snippet.content,
-                        folderTitle: folder.title
+                        folderTitle: folder.title,
+                        snippetType: snippet.snippetType,
+                        scriptShell: snippet.scriptShell,
+                        scriptTimeout: snippet.scriptTimeout,
+                        isEphemeral: snippet.isEphemeral
                     )
                 }
             guard !snippets.isEmpty else { return nil }
@@ -254,10 +266,33 @@ class SnippetPickerViewModel: ObservableObject {
     func pasteSnippet(withID id: String) {
         for folder in allFolders {
             if let snippet = folder.snippets.first(where: { $0.id == id }) {
-                let processed = SnippetVariableProcessor.process(snippet.content)
                 UsageMetricsService.shared.track(.snippetPasted)
-                AppEnvironment.current.pasteService.copyToPasteboard(with: processed)
-                SnippetPickerWindowController.shared.dismissAndPaste()
+
+                if snippet.isScript {
+                    // Dismiss picker first, then run script async and paste output
+                    let ephemeral = snippet.isEphemeral
+                    SnippetPickerWindowController.shared.dismiss()
+                    ScriptExecutionService.execute(
+                        script: snippet.content,
+                        shell: snippet.scriptShell,
+                        timeout: TimeInterval(snippet.scriptTimeout)
+                    ) { result in
+                        if !result.timedOut && result.exitCode == 0 {
+                            if ephemeral {
+                                AppEnvironment.current.pasteService.pasteEphemeral(with: result.output)
+                            } else {
+                                AppEnvironment.current.pasteService.copyToPasteboard(with: result.output)
+                                AppEnvironment.current.pasteService.paste()
+                            }
+                        } else {
+                            NSSound.beep()
+                        }
+                    }
+                } else {
+                    let processed = SnippetVariableProcessor.process(snippet.content)
+                    AppEnvironment.current.pasteService.copyToPasteboard(with: processed)
+                    SnippetPickerWindowController.shared.dismissAndPaste()
+                }
                 return
             }
         }
@@ -504,14 +539,14 @@ struct SnippetPickerPanelView: View {
                 .foregroundStyle(isSelected ? .white.opacity(0.7) : .secondary.opacity(0.5))
                 .frame(width: 18)
 
-            Image(systemName: snippet.hasVariables ? "function" : "doc.text.fill")
+            Image(systemName: snippet.isScript ? "terminal.fill" : snippet.hasVariables ? "function" : "doc.text.fill")
                 .font(.system(size: 10, weight: .medium))
-                .foregroundStyle(isSelected ? AnyShapeStyle(.white) : snippet.hasVariables ? AnyShapeStyle(.orange) : AnyShapeStyle(.blue))
+                .foregroundStyle(isSelected ? AnyShapeStyle(.white) : snippet.isScript ? AnyShapeStyle(.green) : snippet.hasVariables ? AnyShapeStyle(.orange) : AnyShapeStyle(.blue))
                 .frame(width: 22, height: 22)
                 .background(
                     isSelected
                         ? AnyShapeStyle(.white.opacity(0.15))
-                        : AnyShapeStyle(snippet.hasVariables ? SwiftUI.Color.orange.opacity(0.08) : SwiftUI.Color.blue.opacity(0.08))
+                        : AnyShapeStyle(snippet.isScript ? SwiftUI.Color.green.opacity(0.08) : snippet.hasVariables ? SwiftUI.Color.orange.opacity(0.08) : SwiftUI.Color.blue.opacity(0.08))
                 )
                 .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
 
@@ -522,7 +557,15 @@ struct SnippetPickerPanelView: View {
                         .foregroundStyle(isSelected ? .white : .primary)
                         .lineLimit(1)
 
-                    if snippet.hasVariables {
+                    if snippet.isScript {
+                        Text("SCRIPT")
+                            .font(.system(size: 8, weight: .bold, design: .rounded))
+                            .foregroundStyle(isSelected ? .white.opacity(0.7) : .green)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(isSelected ? .white.opacity(0.15) : SwiftUI.Color.green.opacity(0.12))
+                            .clipShape(Capsule())
+                    } else if snippet.hasVariables {
                         Text("%VAR")
                             .font(.system(size: 8, weight: .bold, design: .rounded))
                             .foregroundStyle(isSelected ? .white.opacity(0.7) : .orange)

--- a/Clipy/Sources/Views/SnippetPicker/SnippetPickerPanel.swift
+++ b/Clipy/Sources/Views/SnippetPicker/SnippetPickerPanel.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 //
 //  SnippetPickerPanel.swift
 //

--- a/Clipy/Sources/Views/SnippetPicker/SnippetPickerPanel.swift
+++ b/Clipy/Sources/Views/SnippetPicker/SnippetPickerPanel.swift
@@ -276,15 +276,16 @@ class SnippetPickerViewModel: ObservableObject {
                         shell: snippet.scriptShell,
                         timeout: TimeInterval(snippet.scriptTimeout)
                     ) { result in
-                        if !result.timedOut && result.exitCode == 0 {
-                            if ephemeral {
-                                AppEnvironment.current.pasteService.pasteEphemeral(with: result.output)
-                            } else {
-                                AppEnvironment.current.pasteService.copyToPasteboard(with: result.output)
-                                AppEnvironment.current.pasteService.paste()
-                            }
+                        if result.timedOut {
+                            Self.showScriptError("Script timed out after \(snippet.scriptTimeout)s")
+                        } else if result.exitCode != 0 {
+                            let detail = result.error ?? "No error output"
+                            Self.showScriptError("Script failed (exit \(result.exitCode)): \(detail)")
+                        } else if ephemeral {
+                            AppEnvironment.current.pasteService.pasteEphemeral(with: result.output)
                         } else {
-                            NSSound.beep()
+                            AppEnvironment.current.pasteService.copyToPasteboard(with: result.output)
+                            AppEnvironment.current.pasteService.paste()
                         }
                     }
                 } else {
@@ -295,6 +296,15 @@ class SnippetPickerViewModel: ObservableObject {
                 return
             }
         }
+    }
+
+    private static func showScriptError(_ message: String) {
+        let alert = NSAlert()
+        alert.messageText = "Script Snippet Error"
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
     }
 
     func pasteQuickIndex(_ index: Int) {


### PR DESCRIPTION
## Summary
- **Script snippets (#57)** — New snippet type that executes shell scripts and pastes the output. Includes shell selector, timeout, Test Run button, and visual cues (terminal icon, SCRIPT badge) across the editor, picker, and menu.
- **Plugin system (#38)** — Lightweight architecture for clip processors via `~/.clipy/plugins/` with manifest.json. Auto-trigger and manual plugins, file watching with debounced reload, and a Plugins tab in Preferences.
- **Ephemeral paste (security)** — Script snippet outputs are **not saved to clipboard history** by default. ClipService skip mechanism prevents secrets from persisting to Realm/disk. Pasteboard auto-clears after a configurable delay (default 30s). Per-snippet toggle in the editor.
- **Snippet templates (#58)** — Template gallery with 14 built-in script templates. AWS templates reworked with hardcoded profile/secret placeholders (not clipboard-dependent): SSO Credentials, Secret Fetch, Secret Field extraction, and SSM Parameter Store.

## New files
| File | Purpose |
|------|---------|
| `ScriptExecutionService.swift` | Runs shell scripts via Process with timeout, pipe-safe I/O, NSLock-guarded timeout flag |
| `Plugin.swift` | Plugin model with Codable manifest.json schema |
| `PluginManager.swift` | Scans plugin dir, parses manifests, runs plugins, file watcher |
| `SnippetTemplates.swift` | 14 built-in script templates across 7 categories |

## Modified files
| File | Changes |
|------|---------|
| `CPYSnippet.swift` | Added `snippetType`, `scriptShell`, `scriptTimeout`, `isEphemeral` + `SnippetType` enum + default constants |
| `Realm+Migration.swift` | Schema v10 → v12 (script fields + ephemeral) |
| `ClipService.swift` | `skipNextCapture()` mechanism for ephemeral paste, auto-plugin hook |
| `PasteService.swift` | `pasteEphemeral(with:)` — skips history + auto-clears pasteboard |
| `AppDelegate.swift` | Script execution branch + ephemeral paste in snippet menu action |
| `SnippetPickerPanel.swift` | `isScript`/`isEphemeral` in PickerSnippet, ephemeral paste flow |
| `ModernSnippetsEditor.swift` | Text/Script toggle, shell/timeout/ephemeral settings, Test Run, template gallery sheet |
| `MenuManager.swift` | Terminal icon + [Script] tooltip for script snippets |
| `ModernPreferencesWindow.swift` | Plugins tab, auto-clear ephemeral preference |
| `CPYSnippetsEditorWindowController.swift` | Script fields in XML import/export |
| `Constants.swift` | `ephemeralAutoClearSeconds` key |
| `CPYUtilities.swift` | Default 30s auto-clear registration |

## Security design
Script snippet outputs are ephemeral by default — they're pasted but never stored in Realm, never archived to disk, and auto-cleared from the pasteboard. This prevents Clipy from becoming a plaintext credential store when used with secret management tools.

## Test plan
- [ ] Create a plain text snippet → verify existing behavior unchanged
- [ ] Create a script snippet (`echo "hello"`) → verify output is pasted
- [ ] Test Run button → verify output shown in editor panel
- [ ] Ephemeral ON (default): paste script output → verify it does NOT appear in clipboard history
- [ ] Ephemeral OFF: paste script output → verify it DOES appear in history
- [ ] Auto-clear: paste ephemeral → wait 30s → verify pasteboard is empty
- [ ] Timeout: script with `sleep 30` → verify killed after timeout
- [ ] Template gallery: browse templates, add one → verify snippet created with placeholder config
- [ ] Preferences → Plugins tab → verify empty state, Open Folder button
- [ ] Preferences → General → auto-clear picker (Off/15s/30s/60s)
- [ ] XML export → import → verify script snippet fields roundtrip
- [ ] Visual: script snippets show green terminal icon + SCRIPT badge in picker/sidebar/menu

Closes #38, closes #57, closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)