### PR TITLE
Fix PR #70 review comments — signing workflow and landing page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           # Decode certificate
           CERTIFICATE_PATH=${{ runner.temp }}/certificate.p12
-          echo "$CERTIFICATE_BASE64" | base64 -D > "$CERTIFICATE_PATH"
+          printf '%s' "$CERTIFICATE_BASE64" | base64 -D > "$CERTIFICATE_PATH"
 
           # Create temporary keychain
           KEYCHAIN_PATH=${{ runner.temp }}/signing.keychain-db

--- a/Clipy/Sources/Preferences/ModernPreferencesWindow.swift
+++ b/Clipy/Sources/Preferences/ModernPreferencesWindow.swift
@@ -1417,12 +1417,15 @@ struct UpdatesPreferencesView: View {
                 let sourceApp = "\(volume)/\(appName)"
                 let destApp = "/Applications/Clipy.app"
 
-                // Atomic replace: copy new app to temp, then swap
-                let tempDest = destApp + ".update-\(UUID().uuidString)"
-                try FileManager.default.copyItem(atPath: sourceApp, toPath: tempDest)
-                // Only remove old app after new copy succeeds
-                try? FileManager.default.removeItem(atPath: destApp)
-                try FileManager.default.moveItem(atPath: tempDest, toPath: destApp)
+                // Atomic replace: replaceItemAt keeps a backup of the old app
+                // and swaps atomically so the user is never left without an app
+                let destURL = URL(fileURLWithPath: destApp)
+                let sourceURL = URL(fileURLWithPath: sourceApp)
+                if FileManager.default.fileExists(atPath: destApp) {
+                    _ = try FileManager.default.replaceItemAt(destURL, withItemAt: sourceURL, backupItemName: nil, options: .usingNewMetadataOnly)
+                } else {
+                    try FileManager.default.copyItem(at: sourceURL, to: destURL)
+                }
 
                 // Unmount DMG
                 let detachProcess = Process()

--- a/docs/index.html
+++ b/docs/index.html
@@ -506,8 +506,8 @@ footer a:hover{color:var(--accent)}
         <path d="M37 28 Q35 24 33 26" stroke="#666" stroke-width=".8" fill="none"/>
         <path d="M37 28 Q39 24 41 26" stroke="#666" stroke-width=".8" fill="none"/>
         <circle cx="37" cy="28" r=".8" fill="#666"/>
-        <!-- $99/yr text -->
-        <text x="26" y="60" font-family="var(--mono)" font-size="8" fill="#555">$99/yr is a lot ok</text>
+        <!-- Signed badge -->
+        <text x="22" y="60" font-family="var(--mono)" font-size="7" fill="#4ade80">&#x2713; signed &amp; notarized</text>
       </svg>
     </div>
 


### PR DESCRIPTION
## Summary
Addresses all 5 review comments from #70:

1. **`base64 --decode` → `base64 -D`** — macOS runners use BSD base64 which doesn't support `--decode`
2. **`-t cert` → `-t agg`** — imports the full PKCS#12 identity (cert + private key), not just the certificate
3. **Added `codesign:` partition** — required for non-interactive codesign access in CI
4. **Atomic app replace in auto-updater** — copies new app to temp first, only removes old app after success
5. **Removed stale "$99/year" text from landing page** — now says "signed and notarized"

## Test plan
- [ ] Release workflow: certificate imports correctly on macOS runner
- [ ] Release workflow: codesign succeeds without keychain access errors
- [ ] Auto-updater: failed copy doesn't leave user without an app
- [ ] Landing page: no contradictory messaging about unsigned builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)