### PR TITLE
Fix #90: Edit Snippets window has no way to close

### DIFF
--- a/Clipy/Sources/Snippets/ModernSnippetsEditor.swift
+++ b/Clipy/Sources/Snippets/ModernSnippetsEditor.swift
@@ -1254,16 +1254,13 @@ class ModernSnippetsWindowController: NSWindowController {
     private init() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 740, height: 520),
-            styleMask: [.titled, .fullSizeContentView],
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: true
         )
         window.title = "Snippets"
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .hidden
-        window.standardWindowButton(.closeButton)?.isHidden = true
-        window.standardWindowButton(.miniaturizeButton)?.isHidden = true
-        window.standardWindowButton(.zoomButton)?.isHidden = true
         window.isMovableByWindowBackground = true
         window.backgroundColor = .clear
         window.isOpaque = false

--- a/Clipy/Sources/Snippets/ModernSnippetsEditor.swift
+++ b/Clipy/Sources/Snippets/ModernSnippetsEditor.swift
@@ -510,11 +510,11 @@ struct ModernSnippetsEditorView: View {
         Button(action: onClose) {
             ZStack {
                 Circle()
-                    .fill(closeButtonHovered ? Color.red.opacity(0.85) : Color.secondary.opacity(0.18))
+                    .fill(closeButtonHovered ? SwiftUI.Color.red.opacity(0.85) : SwiftUI.Color.secondary.opacity(0.18))
                     .frame(width: 14, height: 14)
                 Image(systemName: "xmark")
                     .font(.system(size: 8, weight: .heavy))
-                    .foregroundStyle(closeButtonHovered ? Color.white : Color.secondary)
+                    .foregroundStyle(closeButtonHovered ? SwiftUI.Color.white : SwiftUI.Color.secondary)
                     .opacity(closeButtonHovered ? 1 : 0.7)
             }
         }

--- a/Clipy/Sources/Snippets/ModernSnippetsEditor.swift
+++ b/Clipy/Sources/Snippets/ModernSnippetsEditor.swift
@@ -503,7 +503,28 @@ extension SnippetsEditorViewModel {
 struct ModernSnippetsEditorView: View {
     @StateObject private var viewModel = SnippetsEditorViewModel()
     @FocusState private var sidebarFocused: Bool
+    @State private var closeButtonHovered = false
     let onClose: () -> Void
+
+    private var closeButton: some View {
+        Button(action: onClose) {
+            ZStack {
+                Circle()
+                    .fill(closeButtonHovered ? Color.red.opacity(0.85) : Color.secondary.opacity(0.18))
+                    .frame(width: 14, height: 14)
+                Image(systemName: "xmark")
+                    .font(.system(size: 8, weight: .heavy))
+                    .foregroundStyle(closeButtonHovered ? Color.white : Color.secondary)
+                    .opacity(closeButtonHovered ? 1 : 0.7)
+            }
+        }
+        .buttonStyle(.plain)
+        .keyboardShortcut("w", modifiers: .command)
+        .onHover { closeButtonHovered = $0 }
+        .padding(.top, 12)
+        .padding(.leading, 12)
+        .help("Close (\u{2318}W)")
+    }
 
     var body: some View {
         HStack(spacing: 0) {
@@ -520,6 +541,7 @@ struct ModernSnippetsEditorView: View {
             RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .strokeBorder(.white.opacity(0.12), lineWidth: 0.5)
         )
+        .overlay(closeButton, alignment: .topLeading)
         .overlay(DevBadgeOverlay())
         .onAppear { viewModel.load() }
         .onChange(of: viewModel.needsRefocus) { _, needs in
@@ -1261,6 +1283,12 @@ class ModernSnippetsWindowController: NSWindowController {
         window.title = "Snippets"
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .hidden
+        // Native traffic-light buttons sit in transparent space outside the rounded
+        // content area — hide them. The custom close button in SwiftUI handles clicks,
+        // and Cmd+W / Cmd+M still work natively via the styleMask flags.
+        window.standardWindowButton(.closeButton)?.isHidden = true
+        window.standardWindowButton(.miniaturizeButton)?.isHidden = true
+        window.standardWindowButton(.zoomButton)?.isHidden = true
         window.isMovableByWindowBackground = true
         window.backgroundColor = .clear
         window.isOpaque = false

--- a/Clipy/Sources/Snippets/ModernSnippetsEditor.swift
+++ b/Clipy/Sources/Snippets/ModernSnippetsEditor.swift
@@ -521,18 +521,27 @@ struct ModernSnippetsEditorView: View {
         .buttonStyle(.plain)
         .keyboardShortcut("w", modifiers: .command)
         .onHover { closeButtonHovered = $0 }
-        .padding(.top, 12)
         .padding(.leading, 12)
         .help("Close (\u{2318}W)")
     }
 
     var body: some View {
-        HStack(spacing: 0) {
-            sidebar
-                .frame(width: 260)
-            Divider().opacity(0.4)
-            editorPane
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        VStack(spacing: 0) {
+            // Thin custom titlebar — provides space for the close button without
+            // overlapping the sidebar's search bar
+            HStack(spacing: 0) {
+                closeButton
+                Spacer()
+            }
+            .frame(height: 28)
+
+            HStack(spacing: 0) {
+                sidebar
+                    .frame(width: 260)
+                Divider().opacity(0.4)
+                editorPane
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
         }
         .frame(width: 740, height: 520)
         .background(.regularMaterial)
@@ -541,7 +550,6 @@ struct ModernSnippetsEditorView: View {
             RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .strokeBorder(.white.opacity(0.12), lineWidth: 0.5)
         )
-        .overlay(closeButton, alignment: .topLeading)
         .overlay(DevBadgeOverlay())
         .onAppear { viewModel.load() }
         .onChange(of: viewModel.needsRefocus) { _, needs in


### PR DESCRIPTION
Fixes #90

## Problem

User @nordicdata reported that the Edit Snippets window has no way to close — no close button, no menu option, nothing visible.

## Why this took two iterations

The original code went for a "floating rounded panel" aesthetic — clear window background, opaque off, content clipped to a `RoundedRectangle(cornerRadius: 12)`, with the standard traffic-light buttons explicitly hidden:

```swift
window.backgroundColor = .clear
window.isOpaque = false
.background(.regularMaterial)
.clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
```

There's an ESC key handler in `showWindow(_:)`, but it's completely undiscoverable.

**First attempt** was to simply add `.closable / .miniaturizable / .resizable` back to the styleMask so the standard traffic lights would appear. But that didn't actually surface anything — the window's background is invisible (transparent), and the SwiftUI rounded panel sits inside it with the traffic lights drawn in transparent space *outside* the visible content area. Users still couldn't see them.

## Final approach: custom close button, keep the floating design

Two real options:

1. **Switch to a standard macOS window** with the system titlebar and traffic lights. Visually loud, doesn't fit the rest of the app's design language (search panel, snippet picker, preferences all use the same liquid-glass aesthetic).
2. **Keep the floating panel and add a custom close button** matching the design language.

We tested option 1 and it broke the visual cohesion — the snippet editor would have been the only window in the app with a heavy native chrome. Option 2 wins on consistency.

## What changed

- Added a small custom close button (`xmark` SF symbol inside a circle) in a thin 28pt titlebar row above the sidebar/editor split. Subtle by default (light grey circle), turns red on hover — mimics macOS traffic-light affordance.
- `keyboardShortcut("w", modifiers: .command)` so Cmd+W still works natively.
- ESC continues to close via the existing local key monitor (preserved as a power-user shortcut).
- Kept `.closable` etc in the styleMask so macOS still treats it as a closable window for system-level handling.
- Re-hid the standard traffic-light buttons (they sit in invisible window space and would be accidentally clickable).

## Test plan

- [x] Build succeeds (had to qualify as `SwiftUI.Color` because SwiftGen's `Colors.swift` typealiases `Color = NSColor` at module scope)
- [x] Custom close button visible in top-left of titlebar row
- [x] Clicking the button closes the window
- [x] Cmd+W closes the window
- [x] ESC closes the window (existing behavior preserved)
- [x] Hover state turns the button red

🤖 Generated with [Claude Code](https://claude.com/claude-code)