### PR TITLE
Release v2.2.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-05-09
+
+### Added
+- **Script snippets** — new snippet type that runs shell scripts and pastes the output. Configurable shell (`/bin/bash`, `/bin/zsh`, `/bin/sh`, `/usr/bin/python3`), per-snippet timeout, and a Test Run button in the editor.
+- **Template gallery** — 15 built-in script templates with parameter forms:
+  - **AWS**: SSO Credentials, Secret Fetch (Secrets Manager), Secret Field (JSON key extraction), SSM Parameter
+  - **Format**: JSON Pretty Print, JSON Minify
+  - **Encode**: Base64 Encode/Decode, URL Encode
+  - **Security**: JWT Decode Payload
+  - **Convert**: Epoch to Date, Markdown to HTML
+  - **Generate**: UUID, Password
+- **Plugin system** — drop a folder with `manifest.json` into `~/.clipy/plugins/` to register custom clip processors. Auto-trigger plugins run on every capture, manual ones run on demand. New Plugins tab in Preferences.
+- **Ephemeral paste** — script snippet output bypasses clipboard history by default, so secrets do not get saved. Optional auto-clear of the pasteboard after a configurable delay.
+- **Path traversal protection** — plugin commands are validated to be relative paths within the plugin directory.
+
+### Fixed
+- **History folders not appearing in the menu** ([#88](https://github.com/jeanluciradukunda/Clipy/issues/88)) — the menu was hardcoded to show only 5 clips, ignoring the user's `Items shown inline`, `Items per folder`, and `Max history size` preferences. Replaced with the function that respects those settings, plus fixed an off-by-N indexing bug in submenu lookups.
+- **Pinned image / PDF / file clips lost their pin indicator** — the 📌 emoji was overwritten by type-specific titles like `(Image)`. Now applied last so it survives the override.
+- **10th menu item displayed as "0." instead of "10."** — inherited ClipMenu behavior wrapped the title number to match the `⌘0` shortcut. The title now shows the real position; the keyboard shortcut still uses `⌘0` (since `⌘10` does not exist on a keyboard).
+- **Edit Snippets window had no way to close** ([#90](https://github.com/jeanluciradukunda/Clipy/issues/90)) — added a custom close button in the top-left of the floating panel, matching the app's design language. `⌘W` and `ESC` also work.
+- **Script execution pipe deadlock** — long-running scripts producing more than 1 MB of output could hang waiting for the pipe buffer to drain. Now drains fully to EOF, discarding bytes past the limit.
+- **Script timeouts could hang** — if a child process ignored `SIGTERM`, the timeout was effectively infinite. Now escalates to `SIGKILL` after a 2 second grace period.
+- **`isEphemeral` snippet field not preserved on import/export** — the security toggle for script snippets now round-trips correctly through XML export and import in both the modern and legacy editors.
+- **Async plugin loading** — filesystem traversal and JSON decoding moved off the main actor so the Preferences window does not stutter when many plugins are installed.
+
+### Security
+- **Plugins disabled by default** on first discovery — auto-trigger plugins now require explicit opt-in to reduce the risk of unintended clipboard exfiltration.
+- **Ephemeral paste change-count tracking** — auto-clear now compares `NSPasteboard.changeCount` against the value at write time instead of doing a string match, so the user's real clipboard cannot be wiped if they happen to copy the same string later.
+
 ## [2.0.0] - 2026-03-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Script snippets** — new snippet type that runs shell scripts and pastes the output. Configurable shell (`/bin/bash`, `/bin/zsh`, `/bin/sh`, `/usr/bin/python3`), per-snippet timeout, and a Test Run button in the editor.
-- **Template gallery** — 15 built-in script templates with parameter forms:
+- **Template gallery** — 14 built-in script templates with parameter forms:
   - **AWS**: SSO Credentials, Secret Fetch (Secrets Manager), Secret Field (JSON key extraction), SSM Parameter
   - **Format**: JSON Pretty Print, JSON Minify
   - **Encode**: Base64 Encode/Decode, URL Encode


### PR DESCRIPTION
Adds the v2.2.0 entry to CHANGELOG.md ahead of cutting the release.

### Highlights

**Added**: script snippets, 14-template gallery (4 AWS), plugin system, ephemeral paste

**Fixed**: history folders not appearing (#88), pinned image clips lost pin emoji, 10th menu item showed "0.", Edit Snippets window had no close button (#90), pipe deadlock for >1MB script output, SIGTERM-ignoring scripts hung forever, isEphemeral round-trip on import/export, async plugin loading

**Security**: plugins disabled by default, ephemeral auto-clear uses changeCount tracking instead of string match

### Next steps

- [ ] Merge this PR
- [ ] Trigger Release workflow with version 2.2.0
- [ ] Verify DMG downloads and installs cleanly
- [ ] Update site (version badge + What's New)
- [ ] Comment on issues #88 and #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)