### PR TITLE
Hide default disclosure marker on collapsible details

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -959,6 +959,8 @@ h3{font-size:clamp(1.1rem,2vw,1.4rem);font-weight:700}
   padding:12px 0;
   list-style:none;
 }
+.changelog details summary{list-style:none}
+.changelog details summary::-webkit-details-marker{display:none}
 .changelog details summary::before{content:'+ ';color:var(--amber)}
 .changelog details[open] summary::before{content:'- '}
 .changelog details .detail-content{


### PR DESCRIPTION
Follow-up to PR #96 ([Copilot comment](https://github.com/jeanluciradukunda/Clipy/pull/96#discussion_r3213279527)).

Safari/WebKit was rendering both the browser-default triangle marker AND the custom \`+\`/\`-\` marker added via \`summary::before\`. Two-line CSS fix:

\`\`\`css
.changelog details summary { list-style: none; }
.changelog details summary::-webkit-details-marker { display: none; }
\`\`\`

Pre-existing issue (the v2.0 highlights details element had it too), surfaced now that we added a v2.1 highlights one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)