### PR TITLE
Fix #99: prevent cross-build data wipe by separating data folders

### DIFF
--- a/Clipy/Sources/Constants.swift
+++ b/Clipy/Sources/Constants.swift
@@ -20,7 +20,11 @@ struct Constants {
             static let name = "Clipy"
         #endif
         static let appcastURL = URL(string: "https://clipy-app.com/appcast.xml")!
-        static let supportDirectoryName = "ClipyDev"
+        #if DEBUG
+            static let supportDirectoryName = "ClipyDev"
+        #else
+            static let supportDirectoryName = "Clipy"
+        #endif
     }
 
     struct Menu {

--- a/Clipy/Sources/Services/DataCleanService.swift
+++ b/Clipy/Sources/Services/DataCleanService.swift
@@ -75,6 +75,14 @@ final class DataCleanService {
             .filter { !$0.isInvalidated }
             .compactMap { $0.dataPath.components(separatedBy: "/").last })
 
+        // Defence in depth: if the Realm came up with zero clips (fresh install, migration failure,
+        // running a different build that shares the folder, etc) do NOT assume every file on disk
+        // is an orphan. This guard prevents catastrophic data loss in those edge cases.
+        guard !allClipPaths.isEmpty else {
+            logger.warning("Skipping file cleanup: Realm has no clips, refusing to treat all on-disk files as orphans")
+            return
+        }
+
         DispatchQueue.main.async {
             Set(allClipPaths).symmetricDifference(paths)
                 .map { CPYUtilities.applicationSupportFolder() + "/" + "\($0)" }


### PR DESCRIPTION
Fixes #99

## Problem

`Constants.swift:23` hardcodes the support directory name to `"ClipyDev"`, with no `#if DEBUG` guard. Both the Release Clipy and the Dev build write data files into the same folder (`~/Library/Application Support/ClipyDev/`), but each maintains its own Realm database. On every launch, `DataCleanService.cleanFiles` does a symmetric difference between the shared folder and the running build's Realm `dataPath` references and deletes anything it does not recognise. The other build's files all look like orphans and get wiped.

End result: pinned image clips keep their Realm record (the user still sees them in the list), but the underlying binary file is gone, so previews fall back to the `Image data` placeholder.

See the issue for the full evidence including file timestamps from a real instance where pinned image data files older than 1 day had all been deleted.

## Changes

### 1. Build-gate the data folder name (`Clipy/Sources/Constants.swift`)

```swift
#if DEBUG
    static let supportDirectoryName = "ClipyDev"
#else
    static let supportDirectoryName = "Clipy"
#endif
```

Dev and Release each get their own folder. No more cross-contamination.

### 2. Defence in depth in `cleanFiles` (`Clipy/Sources/Services/DataCleanService.swift`)

If the Realm reports zero clips, bail out instead of treating every on-disk file as an orphan. Protects against migration failures, fresh installs landing on a folder seeded by another build, corruption, etc.

## Migration notes

- `CPYClip.dataPath` is stored as an **absolute** path baked into each Realm record at create time. Existing clips in v2.2.0 continue to be readable because their dataPath still points at the old `ClipyDev/` folder.
- New clips created after this fix go to the new folder (`Clipy/` for Release, `ClipyDev/` for Dev).
- No migration step is required.

## Test plan

- [x] Build succeeds (`xcodebuild ... Debug build` → BUILD SUCCEEDED)
- [ ] Launch Dev build, confirm it writes new data files to `~/Library/Application Support/ClipyDev/`
- [ ] Launch Release build, confirm it writes new data files to `~/Library/Application Support/Clipy/`
- [ ] Run both builds in sequence, confirm neither wipes the other's data files
- [ ] Verify old clips (with dataPath pointing at the legacy shared folder) still load their previews

🤖 Generated with [Claude Code](https://claude.com/claude-code)