### PR TITLE
Fix Clear History leaving clip data files on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2026-07-02
+
+### Fixed
+- **Cross-build data wipe** ([#99](https://github.com/jeanluciradukunda/Clipy/issues/99)) — the Release and Dev builds shared `~/Library/Application Support/ClipyDev/` for clip data files while each kept its own database, so every launch of one build deleted the other build's files as orphans. Pinned image clips kept their history entry but lost the underlying image. Data folders are now separated per build (`Clipy/` for Release, `ClipyDev/` for Dev), and the file cleanup refuses to run when the database reports zero clips, as defence in depth against wiping a folder it does not own.
+- **Clear History now erases clip files immediately** — clearing history removed the database records but left the clip data files on disk until a later cleanup pass (a side effect of the new zero-clips safety guard). The files are now deleted at clear time.
+
+### Known limitations
+- Clip data files created by v2.2.0 or earlier remain in the old shared `ClipyDev/` folder. The Release build keeps reading them, but running the Dev build can still clean them up as orphans. If you run both builds and want to keep old pinned images, re-copy them once in the Release build so they are stored in the new folder.
+
 ## [2.2.0] - 2026-05-09
 
 ### Added

--- a/Clipy/Sources/Services/ClipService.swift
+++ b/Clipy/Sources/Services/ClipService.swift
@@ -121,9 +121,13 @@ final class ClipService {
             .filter { !$0.thumbnailPath.isEmpty }
             .map { $0.thumbnailPath }
             .forEach { ClipService.removeCachedThumbnail(forKey: $0) }
+        // Capture data file paths before the Realm records are deleted
+        let dataPaths = clips.map { $0.dataPath }.filter { !$0.isEmpty }
         // Delete Realm
         realm.transaction { realm.delete(clips) }
-        // Delete stored data files
+        // Delete stored data files directly: cleanFiles refuses to sweep when the
+        // Realm has zero clips, so cleared clips' files must be removed here
+        dataPaths.forEach { CPYUtilities.deleteData(at: $0) }
         AppEnvironment.current.dataCleanService.cleanDatas()
     }
 


### PR DESCRIPTION
Follow-up to #100 (found during its review — see [the review comment](https://github.com/jeanluciradukunda/Clipy/pull/100#issuecomment-4870735595)).

## Problem

The zero-clips guard added in #100 stops `cleanFiles` from sweeping when the Realm is empty — which is exactly the state `clearAll()` leaves the Realm in when the user has no pinned clips (or has *Clear includes pinned* enabled). `clearAll()` deleted the Realm records and relied on the sweep to remove the `.data` files, so cleared clipboard contents (including images) stayed on disk until the next clip + 30-minute cleanup cycle re-enabled it. For a privacy-sensitive action like Clear History, files should be erased immediately.

## Change

`clearAll()` now captures each clip's `dataPath` before deleting the Realm records and deletes the files directly. Since `dataPath` is absolute, this also correctly erases legacy files in the old shared `ClipyDev/` folder.

Also adds the **v2.2.1 changelog entry** covering both #99 fixes and the known limitation for legacy files.

## Test plan

- [x] Debug build succeeds (`xcodebuild -workspace ... -configuration Debug build` → BUILD SUCCEEDED)
- [ ] Copy a few clips (including an image), Clear History, confirm the `.data` files are gone from the support folder immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)