### PR TITLE
Fix in-app update failing with Cocoa error 512

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2026-07-03
+
+### Fixed
+- **In-app update failed with "The file "Clipy" couldn't be saved in the folder "Applications""** — a v2.0.x refactor made the updater swap the app directly from the mounted DMG, but the atomic swap (`replaceItemAt`) must take ownership of the source, which the read-only DMG volume forbids (Cocoa error 512). The new app is now staged in a temporary folder first, and the DMG is detached before the swap so a failure can no longer leave a phantom volume mounted.
+
+> **Note for v2.2.0 / v2.2.1 users:** the broken updater ships *inside* those versions, so updating to 2.2.2 requires one manual install — download the DMG from Releases and drag Clipy to Applications. In-app updates work again from 2.2.2 onwards. Your clipboard history and snippets are untouched by updates.
+
 ## [2.2.1] - 2026-07-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **In-app update failed with "The file "Clipy" couldn't be saved in the folder "Applications""** — a v2.0.x refactor made the updater swap the app directly from the mounted DMG, but the atomic swap (`replaceItemAt`) must take ownership of the source, which the read-only DMG volume forbids (Cocoa error 512). The new app is now staged in a temporary folder first, and the DMG is detached before the swap so a failure can no longer leave a phantom volume mounted.
 
-> **Note for v2.2.0 / v2.2.1 users:** the broken updater ships *inside* those versions, so updating to 2.2.2 requires one manual install — download the DMG from Releases and drag Clipy to Applications. In-app updates work again from 2.2.2 onwards. Your clipboard history and snippets are untouched by updates.
-
 ## [2.2.1] - 2026-07-02
 
 ### Fixed

--- a/Clipy/Sources/Preferences/ModernPreferencesWindow.swift
+++ b/Clipy/Sources/Preferences/ModernPreferencesWindow.swift
@@ -1549,25 +1549,32 @@ struct UpdatesPreferencesView: View {
                 let sourceApp = "\(volume)/\(appName)"
                 let destApp = "/Applications/Clipy.app"
 
-                // Atomic replace: replaceItemAt keeps a backup of the old app
-                // and swaps atomically so the user is never left without an app
-                let destURL = URL(fileURLWithPath: destApp)
-                let sourceURL = URL(fileURLWithPath: sourceApp)
-                if FileManager.default.fileExists(atPath: destApp) {
-                    _ = try FileManager.default.replaceItemAt(destURL, withItemAt: sourceURL, backupItemName: nil, options: .usingNewMetadataOnly)
-                } else {
-                    try FileManager.default.copyItem(at: sourceURL, to: destURL)
-                }
+                // Stage the new app in a temp folder first: replaceItemAt is
+                // move-based and cannot take ownership of a source on the
+                // read-only DMG volume (fails with Cocoa error 512), so the
+                // swap must run from a writable copy
+                let stagingDir = FileManager.default.temporaryDirectory.appendingPathComponent("Clipy-update-\(UUID().uuidString)")
+                try FileManager.default.createDirectory(at: stagingDir, withIntermediateDirectories: true)
+                let stagedURL = stagingDir.appendingPathComponent(appName)
+                try FileManager.default.copyItem(at: URL(fileURLWithPath: sourceApp), to: stagedURL)
 
-                // Unmount DMG
+                // Unmount DMG before the swap so a failure cannot leak a mounted volume
                 let detachProcess = Process()
                 detachProcess.executableURL = URL(fileURLWithPath: "/usr/bin/hdiutil")
                 detachProcess.arguments = ["detach", volume, "-quiet"]
                 try? detachProcess.run()
                 detachProcess.waitUntilExit()
-
-                // Clean up
                 try? FileManager.default.removeItem(at: dmgPath)
+
+                // Atomic replace: replaceItemAt keeps a backup of the old app
+                // and swaps atomically so the user is never left without an app
+                let destURL = URL(fileURLWithPath: destApp)
+                if FileManager.default.fileExists(atPath: destApp) {
+                    _ = try FileManager.default.replaceItemAt(destURL, withItemAt: stagedURL, backupItemName: nil, options: .usingNewMetadataOnly)
+                } else {
+                    try FileManager.default.copyItem(at: stagedURL, to: destURL)
+                }
+                try? FileManager.default.removeItem(at: stagingDir)
 
                 // Relaunch
                 await MainActor.run {


### PR DESCRIPTION
## Problem

In-app update fails on both Release and Dev builds with:

> Install failed: The file "Clipy" couldn't be saved in the folder "Applications".

Commit 656535a (PR #71 review feedback) changed the updater to run `FileManager.replaceItemAt` directly against the app on the **mounted DMG**. `replaceItemAt` is move-based — it must take ownership of the source item — and the read-only DMG volume forbids that, so every install attempt throws `NSCocoaErrorDomain` code 512. The failure path also skipped `hdiutil detach`, leaking a mounted `Clipy x.y.z` volume on every failed attempt.

Verified by reproduction (scratch destination, real v2.2.1 DMG): the swap fails with error 512 from the DMG and succeeds from a writable copy.

## Change

Restore the staging step the original updater (PR #44 / v2.0.0) had:

1. Copy the new app from the DMG to a unique temp folder (`copyItem` from a read-only source is fine)
2. Detach the DMG **before** the swap, so a failure can no longer leak a mounted volume
3. Run the same atomic `replaceItemAt` swap from the writable staged copy

The update path only touches the app bundle in /Applications — clipboard history, snippets, and the Realm databases live under Application Support and are never touched by this code.

## Test plan

- [x] Root cause + fix sequence reproduced/verified with a standalone Swift script against the real 2.2.1 DMG (fail from DMG source, succeed from staged copy)
- [x] Debug workspace build succeeds
- [ ] After v2.2.2 is released: in-app update from a 2.2.2 build to the next release completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)