### PR TITLE
Add Tab to cycle the search panel's type filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Cycle the search panel's type filter from the keyboard** ([#107](https://github.com/jeanluciradukunda/Clipy/issues/107)) — `Tab` advances the active filter chip (All → Text → Images → Links → Files → Pinned → Queue, then back to All) and scrolls it into view, so narrowing by type no longer needs the trackpad. Rebindable in Settings → Shortcuts as "Cycle type filter", alongside the other panel shortcuts.
+
 ## [2.2.2] - 2026-07-03
 
 ### Fixed

--- a/Clipy.xcodeproj/project.pbxproj
+++ b/Clipy.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		FA3778931F3B691A003B5BAB /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3778921F3B691A003B5BAB /* AppEnvironment.swift */; };
 		FA3778951F3B6920003B5BAB /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3778941F3B6920003B5BAB /* Environment.swift */; };
 		FA431F021E6718CE00ACFF56 /* Collection+Safe.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA431F011E6718CE00ACFF56 /* Collection+Safe.swift */; };
+		FA610702C1F0DE0000000107 /* ClipFilterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA610701C1F0DE0000000107 /* ClipFilterSpec.swift */; };
 		FA6167921D3ABEB10049FA14 /* FolderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6167911D3ABEB10049FA14 /* FolderSpec.swift */; };
 		FA6167941D3ACCB90049FA14 /* DraggedDataSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6167931D3ACCB90049FA14 /* DraggedDataSpec.swift */; };
 		FA6167961D3ACDD80049FA14 /* SnippetSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6167951D3ACDD80049FA14 /* SnippetSpec.swift */; };
@@ -215,6 +216,7 @@
 		FA3778921F3B691A003B5BAB /* AppEnvironment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
 		FA3778941F3B6920003B5BAB /* Environment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		FA431F011E6718CE00ACFF56 /* Collection+Safe.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Collection+Safe.swift"; sourceTree = "<group>"; };
+		FA610701C1F0DE0000000107 /* ClipFilterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClipFilterSpec.swift; sourceTree = "<group>"; };
 		FA6167911D3ABEB10049FA14 /* FolderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FolderSpec.swift; sourceTree = "<group>"; };
 		FA6167931D3ACCB90049FA14 /* DraggedDataSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DraggedDataSpec.swift; sourceTree = "<group>"; };
 		FA6167951D3ACDD80049FA14 /* SnippetSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnippetSpec.swift; sourceTree = "<group>"; };
@@ -622,6 +624,7 @@
 			isa = PBXGroup;
 			children = (
 				FA08EDF71D1FED7D000D1D13 /* HotKeyServiceSpec.swift */,
+				FA610701C1F0DE0000000107 /* ClipFilterSpec.swift */,
 				FA6167931D3ACCB90049FA14 /* DraggedDataSpec.swift */,
 				FA6167911D3ABEB10049FA14 /* FolderSpec.swift */,
 				FA6167951D3ACDD80049FA14 /* SnippetSpec.swift */,
@@ -983,6 +986,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FA610702C1F0DE0000000107 /* ClipFilterSpec.swift in Sources */,
 				FA6167921D3ABEB10049FA14 /* FolderSpec.swift in Sources */,
 				FA08EDF81D1FED7D000D1D13 /* HotKeyServiceSpec.swift in Sources */,
 				FA6167961D3ACDD80049FA14 /* SnippetSpec.swift in Sources */,

--- a/Clipy/Sources/Constants.swift
+++ b/Clipy/Sources/Constants.swift
@@ -131,6 +131,7 @@ struct Constants {
         static let paste = "kCPYPanelShortcutPaste"
         static let ocr = "kCPYPanelShortcutOCR"
         static let share = "kCPYPanelShortcutShare"
+        static let cycleFilter = "kCPYPanelShortcutCycleFilter"
     }
 
 }

--- a/Clipy/Sources/Preferences/ModernPreferencesWindow.swift
+++ b/Clipy/Sources/Preferences/ModernPreferencesWindow.swift
@@ -1653,6 +1653,7 @@ struct PanelShortcutsList: View {
         ShortcutRow(name: "Delete clip", shortcut: service.delete, onRecord: { service.save($0) })
         ShortcutRow(name: "OCR (image clips)", shortcut: service.ocr, onRecord: { service.save($0) })
         ShortcutRow(name: "Share (image clips)", shortcut: service.share, onRecord: { service.save($0) })
+        ShortcutRow(name: "Cycle type filter", shortcut: service.cycleFilter, onRecord: { service.save($0) })
 
         HStack {
             Spacer()

--- a/Clipy/Sources/Services/PanelShortcutService.swift
+++ b/Clipy/Sources/Services/PanelShortcutService.swift
@@ -52,6 +52,7 @@ class PanelShortcutService: ObservableObject {
     @Published var paste: PanelShortcutDef
     @Published var ocr: PanelShortcutDef
     @Published var share: PanelShortcutDef
+    @Published var cycleFilter: PanelShortcutDef
 
     static let defaultPin = PanelShortcutDef(id: "pin", key: "d", modifiers: NSEvent.ModifierFlags.command.rawValue)
     static let defaultDelete = PanelShortcutDef(id: "delete", key: "backspace", modifiers: NSEvent.ModifierFlags.command.rawValue)
@@ -59,6 +60,7 @@ class PanelShortcutService: ObservableObject {
     static let defaultPaste = PanelShortcutDef(id: "paste", key: "return", modifiers: 0)
     static let defaultOCR = PanelShortcutDef(id: "ocr", key: "o", modifiers: NSEvent.ModifierFlags.command.rawValue)
     static let defaultShare = PanelShortcutDef(id: "share", key: "s", modifiers: NSEvent.ModifierFlags.command.rawValue)
+    static let defaultCycleFilter = PanelShortcutDef(id: "cycleFilter", key: "tab", modifiers: 0)
 
     private init() {
         pin = Self.load(key: Constants.PanelShortcuts.pin, fallback: Self.defaultPin)
@@ -67,6 +69,7 @@ class PanelShortcutService: ObservableObject {
         paste = Self.load(key: Constants.PanelShortcuts.paste, fallback: Self.defaultPaste)
         ocr = Self.load(key: Constants.PanelShortcuts.ocr, fallback: Self.defaultOCR)
         share = Self.load(key: Constants.PanelShortcuts.share, fallback: Self.defaultShare)
+        cycleFilter = Self.load(key: Constants.PanelShortcuts.cycleFilter, fallback: Self.defaultCycleFilter)
     }
 
     func save(_ shortcut: PanelShortcutDef) {
@@ -78,6 +81,7 @@ class PanelShortcutService: ObservableObject {
         case "paste": paste = shortcut; key = Constants.PanelShortcuts.paste
         case "ocr": ocr = shortcut; key = Constants.PanelShortcuts.ocr
         case "share": share = shortcut; key = Constants.PanelShortcuts.share
+        case "cycleFilter": cycleFilter = shortcut; key = Constants.PanelShortcuts.cycleFilter
         default: return
         }
         if let data = try? JSONEncoder().encode(shortcut) {
@@ -92,6 +96,7 @@ class PanelShortcutService: ObservableObject {
         save(Self.defaultPaste)
         save(Self.defaultOCR)
         save(Self.defaultShare)
+        save(Self.defaultCycleFilter)
     }
 
     private static func load(key: String, fallback: PanelShortcutDef) -> PanelShortcutDef {

--- a/Clipy/Sources/Views/SearchPanel/ClipSearchPanel.swift
+++ b/Clipy/Sources/Views/SearchPanel/ClipSearchPanel.swift
@@ -25,6 +25,13 @@ enum ClipFilter: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
+    /// The next chip in the filter bar, wrapping from the last one back to `.all`.
+    var next: ClipFilter {
+        let chips = Self.allCases
+        guard let index = chips.firstIndex(of: self) else { return .all }
+        return chips[(index + 1) % chips.count]
+    }
+
     var icon: String {
         switch self {
         case .all: return "tray.full"
@@ -284,6 +291,10 @@ class ClipSearchViewModel: ObservableObject {
         selectedIndices = [selectedIndex]
     }
 
+    func advanceFilter() {
+        activeFilter = activeFilter.next
+    }
+
     func moveSelection(by offset: Int) {
         guard !clips.isEmpty else { return }
         selectedIndex = max(0, min(clips.count - 1, selectedIndex + offset))
@@ -514,6 +525,12 @@ struct ClipSearchPanelView: View {
                 viewModel.shareSelectedImage()
                 return .handled
             }
+            if shortcuts.matches(press, shortcut: shortcuts.cycleFilter) {
+                withAnimation(.easeOut(duration: 0.15)) {
+                    viewModel.advanceFilter()
+                }
+                return .handled
+            }
             return .ignored
         }
         // Number keys for quick paste — type one digit or two digits quickly (e.g. "15" for item 15)
@@ -553,22 +570,30 @@ struct ClipSearchPanelView: View {
 
     // MARK: - Filter Bar
     private var filterBar: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 6) {
-                ForEach(ClipFilter.allCases) { filter in
-                    FilterChip(
-                        filter: filter,
-                        isActive: viewModel.activeFilter == filter,
-                        count: countFor(filter)
-                    ) {
-                        withAnimation(.easeOut(duration: 0.15)) {
-                            viewModel.activeFilter = filter
+        ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(ClipFilter.allCases) { filter in
+                        FilterChip(
+                            filter: filter,
+                            isActive: viewModel.activeFilter == filter,
+                            count: countFor(filter)
+                        ) {
+                            withAnimation(.easeOut(duration: 0.15)) {
+                                viewModel.activeFilter = filter
+                            }
                         }
+                        .id(filter)
                     }
                 }
+                .padding(.horizontal, 18)
+                .padding(.vertical, 8)
             }
-            .padding(.horizontal, 18)
-            .padding(.vertical, 8)
+            .onChange(of: viewModel.activeFilter) { _, filter in
+                withAnimation(.easeOut(duration: 0.15)) {
+                    proxy.scrollTo(filter, anchor: .center)
+                }
+            }
         }
     }
 
@@ -981,6 +1006,7 @@ struct ClipSearchPanelView: View {
             kbHint(shortcuts.ocr.label, "ocr")
             kbHint(shortcuts.share.label, "share")
             kbHint("\u{21E7}\u{2191}\u{2193}", "select")
+            kbHint(shortcuts.cycleFilter.label, "filter")
             kbHint("1\u{2013}\(viewModel.clips.count)", "quick")
             Spacer()
             if viewModel.selectedIndices.count > 1 {

--- a/Clipy/Sources/Views/SearchPanel/ClipSearchPanel.swift
+++ b/Clipy/Sources/Views/SearchPanel/ClipSearchPanel.swift
@@ -1007,14 +1007,19 @@ struct ClipSearchPanelView: View {
             kbHint(shortcuts.share.label, "share")
             kbHint("\u{21E7}\u{2191}\u{2193}", "select")
             kbHint(shortcuts.cycleFilter.label, "filter")
-            kbHint("1\u{2013}\(viewModel.clips.count)", "quick")
+            // Queue draws from its own data source, so the clip-list counts do not describe it
+            if viewModel.activeFilter != .queue {
+                kbHint("1\u{2013}\(viewModel.clips.count)", "quick")
+            }
             Spacer()
             if viewModel.selectedIndices.count > 1 {
                 Text("\(viewModel.selectedIndices.count) selected")
                     .font(.system(size: 10, weight: .medium))
                     .foregroundStyle(.orange)
             }
-            Text("\(viewModel.clips.count) items")
+            Text(viewModel.activeFilter == .queue
+                 ? "\(queueService.itemCount) queued"
+                 : "\(viewModel.clips.count) items")
                 .font(.system(size: 10, weight: .medium))
                 .foregroundStyle(.tertiary)
         }

--- a/ClipyTests/ClipFilterSpec.swift
+++ b/ClipyTests/ClipFilterSpec.swift
@@ -1,0 +1,47 @@
+import Quick
+import Nimble
+@testable import Clipy
+
+class ClipFilterSpec: QuickSpec {
+    override class func spec() {
+
+        describe("ClipFilter chip order") {
+            it("matches the order shown in the panel's filter bar") {
+                expect(ClipFilter.allCases) == [.all, .text, .images, .links, .files, .pinned, .queue]
+            }
+        }
+
+        describe("ClipFilter.next") {
+            it("advances one step through the chips") {
+                expect(ClipFilter.all.next) == ClipFilter.text
+                expect(ClipFilter.text.next) == ClipFilter.images
+                expect(ClipFilter.images.next) == ClipFilter.links
+                expect(ClipFilter.links.next) == ClipFilter.files
+                expect(ClipFilter.files.next) == ClipFilter.pinned
+                expect(ClipFilter.pinned.next) == ClipFilter.queue
+            }
+
+            it("wraps from the last chip back to All") {
+                expect(ClipFilter.queue.next) == ClipFilter.all
+            }
+
+            it("returns to the starting filter after a full lap") {
+                var filter = ClipFilter.all
+                for _ in 0..<ClipFilter.allCases.count {
+                    filter = filter.next
+                }
+                expect(filter) == ClipFilter.all
+            }
+
+            it("visits every filter exactly once in a lap") {
+                var visited = [ClipFilter]()
+                var filter = ClipFilter.all
+                for _ in 0..<ClipFilter.allCases.count {
+                    visited.append(filter)
+                    filter = filter.next
+                }
+                expect(Set(visited).count) == ClipFilter.allCases.count
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Default global hotkeys (configurable in Settings → Shortcuts):
 |---|---|
 | `Up/Down` | Navigate clips (hold to repeat) |
 | `Shift+Up/Down` | Extend multi-selection |
+| `Tab` | Cycle type filter (All → Text → Images → Links → Files → Pinned → Queue → All) |
 | `Return` | Paste selected clip |
 | `Shift+Return` | Paste as plain text |
 | `1`-`30` (type rapidly) | Quick select by number |


### PR DESCRIPTION
Narrowing the search panel by type (All / Text / Images / Links / Files / Pinned / Queue) required clicking a filter chip, so a keyboard-driven flow had to break to the trackpad. `Tab` now advances the active chip and wraps from Queue back to All.

## Changes
- `ClipFilter.next` steps one place through `allCases` and wraps, so the ring order is the chip order by construction rather than a second list to keep in sync.
- The binding goes through `PanelShortcutService` like every other panel shortcut: it appears in Settings → Shortcuts as "Cycle type filter", defaults to `⇥`, and is rebindable and covered by "Reset All Shortcuts to Defaults".
- Handled inside the existing customizable-shortcut `onKeyPress` block, so it inherits the same precedence as Paste / Pin / Delete / OCR / Share rather than introducing a second dispatch path. Returning `.handled` is what keeps a tab character out of the search field.
- The filter bar scrolls the active chip into view, so cycling to Pinned or Queue no longer leaves it off-screen on the narrow layout.
- Footer hint reads the live binding instead of a hardcoded glyph.

```mermaid
flowchart LR
    K["Tab keyDown"] --> D["digits handler<br/>no match, ignored"]
    D --> C["customizable shortcut block"]
    C -->|matches cycleFilter| A["advanceFilter()"]
    C -->|no match| F["field editor<br/>text insertion"]
    A --> P["activeFilter published"]
    P --> R["applyFilter: results list"]
    P --> S["scrollTo: active chip"]
```

## Verification
- `ClipFilterSpec`: 5 new tests covering chip order, each single step, the Queue → All wrap, a full lap returning to All, and every filter visited exactly once. Suite goes 20 tests / 9 failures on `main` to 25 tests / 9 failures here, so no new failures (the 9 are pre-existing `HotKeyServiceSpec` assertions at identical lines).
- Bare `Tab` reaches the container handler while the search field holds focus, and the field editor does not consume it for focus-ring advancement. Measured on macOS 26.2 by replicating the panel's view structure and `onKeyPress` order and driving synthesized `keyDown` events through `NSApp.sendEvent`.
- `Ctrl+Tab` was measured as an alternative and rejected: no handler fires for it, because `NSWindow` keyboard navigation swallows it below SwiftUI.
- Cycling confirmed working in the Dev build.
- SwiftLint clean: 111 warnings before and after.

Not yet eyeballed: hint density in the footer now that a ninth hint sits at 720pt width, and the new Settings row recording a replacement binding.

Closes #107
